### PR TITLE
fix optional parameter order issue.

### DIFF
--- a/AustinHarris.JsonRpcTest/UnitTest1.cs
+++ b/AustinHarris.JsonRpcTest/UnitTest1.cs
@@ -1321,5 +1321,17 @@ namespace UnitTests
             Assert.IsFalse(result.Result.Contains("error"));
             Assert.AreEqual(expectedResult, result.Result);
         }
+        [TestMethod]
+        public void TestOptionalParametersBoolsAndStrings()
+        {
+            string request =
+                "{\"jsonrpc\":\"2.0\",\"method\":\"TestOptionalParametersBoolsAndStrings\",\"params\":{\"input1\":\"murkel\"},\"Id\":1}";
+            string expectedResult = "{\"jsonrpc\":\"2.0\",\"result\":true,\"id\":1}";
+
+            var result = JsonRpcProcessor.Process(request);
+            result.Wait();
+            Assert.IsFalse(result.Result.Contains("error"));
+            Assert.AreEqual(expectedResult, result.Result);
+        }
     }
 }

--- a/AustinHarris.JsonRpcTest/service.cs
+++ b/AustinHarris.JsonRpcTest/service.cs
@@ -292,6 +292,11 @@ namespace UnitTests
                 input2
             };
         }
+        [JsonRpcMethod]
+        public bool TestOptionalParametersBoolsAndStrings(string input1, bool input2 = true, string input3 = "")
+        {
+            return input2;
+        }
 
     }
 }

--- a/Json-Rpc/Handler.cs
+++ b/Json-Rpc/Handler.cs
@@ -318,7 +318,7 @@ using Newtonsoft.Json.Linq;
             try
             {
                 var results = handle.DynamicInvoke(parameters);
-                var last = parameters.Length>0 ? parameters[paramCount - 1]:null;
+                var last = parameters.LastOrDefault();
                 JsonRpcException contextException;
                 if (Task.CurrentId.HasValue && RpcExceptions.TryRemove(Task.CurrentId.Value, out contextException))
                 {


### PR DESCRIPTION
Hi Austin,

first many thanks for the great framework. 

This is about the handling of optional parameters in Json-Rpc/Handler.cs. 
It is right to assign the default parameters in reverse order but this requires to iterating the missing parameters in reverse order too. I accomplished this by using a for-loop initializing two indexes. One for the resized parameters array and another for the defaultValues. Both of them are controlling the for-loops termination to avoid index-out-of-range issues. 
Further I added a check to complain if there are more missing parmeters than defaultValues.

Best Regards,

Martin