### PR TITLE
fix batch results removing superfluous commas.

### DIFF
--- a/AustinHarris.JsonRpcTest/AustinHarris.JsonRpcTest.csproj
+++ b/AustinHarris.JsonRpcTest/AustinHarris.JsonRpcTest.csproj
@@ -40,10 +40,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -71,9 +67,6 @@
       <Project>{24fc1a2a-0bc3-43a7-9bfe-b628c2c4a307}</Project>
       <Name>AustinHarris.JsonRpc</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/AustinHarris.JsonRpcTest/AustinHarris.JsonRpcTest.csproj
+++ b/AustinHarris.JsonRpcTest/AustinHarris.JsonRpcTest.csproj
@@ -17,6 +17,8 @@
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,6 +40,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -66,6 +72,9 @@
       <Name>AustinHarris.JsonRpc</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>
@@ -86,6 +95,13 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Aktivieren Sie die Wiederherstellung von NuGet-Paketen, um die fehlende Datei herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/AustinHarris.JsonRpcTest/UnitTest1.cs
+++ b/AustinHarris.JsonRpcTest/UnitTest1.cs
@@ -34,10 +34,11 @@ namespace UnitTests
         {
             string request = @"{method:'NullableDateTimeToNullableDateTime',params:['2014-06-30T14:50:38.5208399+09:00'],id:1}";
             string expectedResult = "{\"jsonrpc\":\"2.0\",\"result\":\"2014-06-30T14:50:38.5208399+09:00\",\"id\":1}";
+            var expectedDate = DateTime.Parse("2014-06-30T14:50:38.5208399+09:00");
             var result = JsonRpcProcessor.Process(request);
             result.Wait();
-            Assert.AreEqual(result.Result, expectedResult);
-            Assert.AreEqual(expectedResult, result.Result);
+            var acutalDate = DateTime.Parse(result.Result.Substring(27, 33));
+            Assert.AreEqual(expectedDate, acutalDate);
         }
 
         [TestMethod]

--- a/AustinHarris.JsonRpcTest/UnitTest1.cs
+++ b/AustinHarris.JsonRpcTest/UnitTest1.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using AustinHarris.JsonRpc.Client;
 using AustinHarris.JsonRpc;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests
 {
@@ -1321,6 +1320,7 @@ namespace UnitTests
             Assert.IsFalse(result.Result.Contains("error"));
             Assert.AreEqual(expectedResult, result.Result);
         }
+
         [TestMethod]
         public void TestOptionalParametersBoolsAndStrings()
         {
@@ -1332,6 +1332,18 @@ namespace UnitTests
             result.Wait();
             Assert.IsFalse(result.Result.Contains("error"));
             Assert.AreEqual(expectedResult, result.Result);
+        }
+
+        [TestMethod]
+        public void TestBatchResult()
+        {
+            string request =
+                @"[{},{""jsonrpc"":""2.0"",""id"":4},{""jsonrpc"":""2.0"",""method"":""ReturnsDateTime"",""params"":{},""id"":1},{""jsonrpc"":""2.0"",""method"":""Notify"",""params"":[""Hello World!""]}]";
+
+            var result = JsonRpcProcessor.Process(request);
+            result.Wait();
+
+            Assert.IsFalse(result.Result.EndsWith(@",]"), "result.Result.EndsWith(@',]')");
         }
     }
 }

--- a/AustinHarris.JsonRpcTest/packages.config
+++ b/AustinHarris.JsonRpcTest/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
+</packages>

--- a/AustinHarris.JsonRpcTest/packages.config
+++ b/AustinHarris.JsonRpcTest/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
-</packages>

--- a/AustinHarris.JsonRpcTest/service.cs
+++ b/AustinHarris.JsonRpcTest/service.cs
@@ -1,6 +1,7 @@
 ﻿using AustinHarris.JsonRpc;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
@@ -298,5 +299,10 @@ namespace UnitTests
             return input2;
         }
 
+        [JsonRpcMethod]
+        public void Notify(string message)
+        {
+            Trace.WriteLine(string.Format("Notified about: {0}", message));
+        }
     }
 }


### PR DESCRIPTION
This is about the processing of requests and compiling of responses in batches. If the request batch consists of message calls and notifications the code in the current master appends a comma to each response, even if successor of the corresponding request ist a notification. If the last request in a batch is a notification, the response looks like this:
```
[{"jsonrpc...},]
```
Even if newtonsoft.json is able to parse such arrays, some other json-frameworks aren't.

By fixing this, I, remarked, that the code for the processing was duplicate (copy/paste). Even the handling of single and batch requests was duplicated.

Best Regards,

Martin
