### PR TITLE
fix [] response on single notification

### DIFF
--- a/AustinHarris.JsonRpcTest/UnitTest1.cs
+++ b/AustinHarris.JsonRpcTest/UnitTest1.cs
@@ -1340,10 +1340,16 @@ namespace UnitTests
             string request =
                 @"[{},{""jsonrpc"":""2.0"",""id"":4},{""jsonrpc"":""2.0"",""method"":""ReturnsDateTime"",""params"":{},""id"":1},{""jsonrpc"":""2.0"",""method"":""Notify"",""params"":[""Hello World!""]}]";
 
+            var secondRequest = @"{""jsonrpc"":""2.0"",""method"":""Notify"",""params"":[""Hello World!""]}";
             var result = JsonRpcProcessor.Process(request);
             result.Wait();
 
             Assert.IsFalse(result.Result.EndsWith(@",]"), "result.Result.EndsWith(@',]')");
+
+            result = JsonRpcProcessor.Process(secondRequest);
+            result.Wait();
+
+            Assert.IsTrue(string.IsNullOrEmpty(result.Result));
         }
     }
 }

--- a/AustinHarris.JsonRpcTest/UnitTest1.cs
+++ b/AustinHarris.JsonRpcTest/UnitTest1.cs
@@ -1350,6 +1350,17 @@ namespace UnitTests
             result.Wait();
 
             Assert.IsTrue(string.IsNullOrEmpty(result.Result));
+
+            result = JsonRpcProcessor.Process(@"[{""jsonrpc"":""2.0"",""method"":""ReturnsDateTime"",""params"":{},""id"":1},{""jsonrpc"":""2.0"",""method"":""ReturnsDateTime"",""params"":{},""id"":1}]");
+            result.Wait();
+
+            Assert.IsTrue(result.Result.EndsWith("]"));
+
+            result =
+                JsonRpcProcessor.Process(@"{""jsonrpc"":""2.0"",""method"":""ReturnsDateTime"",""params"":{},""id"":1}]");
+            result.Wait();
+            Assert.IsFalse(result.Result.EndsWith("]"));
         }
     }
 }
+

--- a/Json-Rpc/JsonRpcProcessor.cs
+++ b/Json-Rpc/JsonRpcProcessor.cs
@@ -121,7 +121,7 @@ namespace AustinHarris.JsonRpc
                     responses[idx++] = JsonConvert.SerializeObject(resp.Item2);
                 }
 
-                return responses.Length == 1 ? responses[0] : string.Format("[{0}]", string.Join(",", responses));
+                return responses.Length == 0 ? string.Empty : responses.Length == 1 ? responses[0] : string.Format("[{0}]", string.Join(",", responses));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Hi Austin, 

Me again... This is about the batchresult again. If there is processed a single notification there is generated a response consiting of an empty Json Array.

Checking the responses Array Length for == 1 isn't sufficent. The empty result will should be handled too.

Best Regards,

Martin