### PR TITLE
fix omitted parms issue

### DIFF
--- a/AustinHarris.JsonRpcTest/UnitTest1.cs
+++ b/AustinHarris.JsonRpcTest/UnitTest1.cs
@@ -1345,5 +1345,17 @@ namespace UnitTests
 
             Assert.IsFalse(result.Result.EndsWith(@",]"), "result.Result.EndsWith(@',]')");
         }
+
+        [TestMethod]
+        public void TestLeftOutParams()
+        {
+            var request =
+                @"{""jsonrpc"":""2.0"",""method"":""ReturnsDateTime"",""id"":1}";
+
+            var result = JsonRpcProcessor.Process(request);
+            result.Wait();
+
+            Assert.IsFalse(result.Result.Contains(@"error"":{""code"":-32602"), @"According to JSON-RPC 2.0 the ""params"" member MAY be omitted.");
+        }
     }
 }

--- a/Json-Rpc/Handler.cs
+++ b/Json-Rpc/Handler.cs
@@ -200,16 +200,6 @@ using Newtonsoft.Json.Linq;
             {
                 return new JsonResponse() { Result = null, Error = new JsonRpcException(-32601, "Method not found", "The method does not exist / is not available."), Id = Rpc.Id };
             }
-            if (Rpc.Params is ICollection == false)
-            {
-                return new JsonResponse()
-                {
-                    Result = null,
-                    Error = new JsonRpcException(-32602,
-                        "Invalid params", "The number of parameters could not be counted"),
-                    Id = Rpc.Id
-                };
-            }
 
             bool isJObject = Rpc.Params is Newtonsoft.Json.Linq.JObject;
             bool isJArray = Rpc.Params is Newtonsoft.Json.Linq.JArray;
@@ -218,7 +208,13 @@ using Newtonsoft.Json.Linq;
             var metaDataParamCount = metadata.parameters.Count(x => x != null);
             
             var getCount = Rpc.Params as ICollection;
-            var loopCt = getCount.Count;
+            var loopCt = 0;
+            
+            if (getCount != null)
+            {
+                loopCt = getCount.Count;
+            }
+
             var paramCount = loopCt;
             if (paramCount == metaDataParamCount - 1 && metadata.parameters[metaDataParamCount-1].ObjectType.Name.Contains(typeof(JsonRpcException).Name))
             {


### PR DESCRIPTION
Hi Austin,
another section in the [JSON-RPC Spec](http://www.jsonrpc.org/specification#request_object) states:
**params**
A Structured value that holds the parameter values to be used during the invocation of the method. This member MAY be omitted.

This is about proper handling omitted params member.

Best Regards,

Martin