### PR TITLE
Real async workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+.nuget/NuGet.exe

--- a/Json-Rpc/JsonRpcProcessor.cs
+++ b/Json-Rpc/JsonRpcProcessor.cs
@@ -18,6 +18,33 @@ namespace AustinHarris.JsonRpc
             Task.Factory.StartNew(() => AsyncProcessInternal(Handler.DefaultSessionId(), jsonRpc, context, callback));
         }
 
+        public static void AsyncProcess(string sessionId,string jsonRpc, Action<string> callback, object context = null)
+        {
+            Task.Factory.StartNew(() => AsyncProcessInternal(sessionId, jsonRpc, context, callback));
+        }
+
+        /// <summary>
+        /// The callback will be returned to the user, who needs to invoke it in concrete
+        /// service implementation. Call should be made directly from same thread as
+        /// service method is executed. 
+        /// </summary>
+        /// <param name="sessionId">Handler session id</param>
+        /// <returns></returns>
+        public static Action<JsonResponse> GetAsyncProcessCallback(string sessionId = "")
+        {
+            Handler handler;
+            if ("" == sessionId)
+            {
+                handler = Handler.GetSessionHandler(Handler.DefaultSessionId());
+            }
+            else 
+            {
+                handler = Handler.GetSessionHandler(sessionId);
+            } 
+
+            return handler.GetAsyncCallback();
+        }
+
         private static void AsyncProcessInternal(string sessionId, string jsonRpc, object jsonRpcContext, Action<string> callback)
         {
             Handler handler = Handler.GetSessionHandler(sessionId);


### PR DESCRIPTION
Hi, we are using your JSON-RPC.NET library for our project. Actually, the problem is that JsonRpcProcessing is not really asynchronous, only synchronous, so if you have too many long running tasks in your rpc services (or blocking tasks for resources, results etc.), then the work of rpc services and whole JsonRpcProcessing is blocked. Actually, the reason is using TPL, especially Tasks for long running tasks, which could not be the best architecture in this case. We do not want to make lot of changes, so we fixed it with the following code with passing callback to AsyncProcess() method, which will be called after job is completed in concrete service implementation (we use callback for using the result from service method, which called another async method, but could be used in any asynchronous scenario). Try to look at it please. Best regards !   