### PR TITLE
Possibility to specify a method parameter name as it will be referred to by JsonRpc

### DIFF
--- a/Json-Rpc/Attributes.cs
+++ b/Json-Rpc/Attributes.cs
@@ -24,4 +24,27 @@ namespace AustinHarris.JsonRpc
             get { return jsonMethodName; }
         }
     }
+
+    /// <summary>
+    /// Used to assign JsonRpc parameter name to method argument.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false, AllowMultiple = false)]
+    public sealed class JsonRpcParamAttribute : Attribute
+    {
+        readonly string jsonParamName;
+
+        /// <summary>
+        /// Used to assign JsonRpc parameter name to method argument.
+        /// </summary>
+        /// <param name="jsonParamName">Lets you specify the parameter name as it will be referred to by JsonRpc.</param>
+        public JsonRpcParamAttribute(string jsonParamName = "")
+        {
+            this.jsonParamName = jsonParamName;
+        }
+
+        public string JsonParamName
+        {
+            get { return jsonParamName; }
+        }
+    }
 }

--- a/Json-Rpc/JsonRpcService.cs
+++ b/Json-Rpc/JsonRpcService.cs
@@ -37,14 +37,25 @@
                 var paramzs = meth.GetParameters();
 
                 List<Type> parameterTypeArray = new List<Type>();                
-                 for (int i = 0; i < paramzs.Length; i++)
+                for (int i = 0; i < paramzs.Length; i++)
                 {
+                    string paramName;
+                    var paramAttrs = paramzs[i].GetCustomAttributes(typeof(JsonRpcParamAttribute), false);
+                    if (paramAttrs.Length > 0)
+                    {
+                        paramName = ((JsonRpcParamAttribute)paramAttrs[0]).JsonParamName;
+                    }
+                    else
+                    {
+                        paramName = paramzs[i].Name;
+                    }
+
                     // reflection attribute information for optional parameters
                     //http://stackoverflow.com/questions/2421994/invoking-methods-with-optional-parameters-through-reflection
-                    paras.Add(paramzs[i].Name, paramzs[i].ParameterType);
+                    paras.Add(paramName, paramzs[i].ParameterType);
 
                     if (paramzs[i].IsOptional) // if the parameter is an optional, add the default value to our default values dictionary.
-                        defaultValues.Add(paramzs[i].Name, paramzs[i].DefaultValue);
+                        defaultValues.Add(paramName, paramzs[i].DefaultValue);
                 }
 
                 var resType = meth.ReturnType;


### PR DESCRIPTION
Hi! I think it would be useful to have a possibility to specify JsonRpc parameters names for the arguments of service method, so that method argument and JsonRpc parameter name can be different.

For example, the following JsonRpc invokation can be used

    {"jsonrpc": "2.0",  "method": "Inc", "params": { "value": 5}, "id": 1}

to call a method defined like this:

    [JsonRpcMethod]
    public int Inc([JsonRpcParam("value")]int a)
    {
        return a + 1;
    }


