### PR TITLE
Possibility to specify a method parameter name as it will be referred to by JsonRpc (with unit test)

### DIFF
--- a/AustinHarris.JsonRpcTestN/Test.cs
+++ b/AustinHarris.JsonRpcTestN/Test.cs
@@ -1852,6 +1852,23 @@ namespace AustinHarris.JsonRpcTestN
             Assert.AreEqual(JObject.Parse(expectedResultAfterDestroy), JObject.Parse(result2.Result));
         }
 
+        [Test()]
+        public void TestCustomParameterName()
+        {
+            Func<string, string> request = (string paramName) => String.Format("{{method:'TestCustomParameterName',params:{{ {0}:'some string'}},id:1}}", paramName);
+            string expectedResult = "{\"jsonrpc\":\"2.0\",\"result\":true,\"id\":1}";
+
+            // Check custom param name specified in attribute works
+            var result = JsonRpcProcessor.Process(request("myCustomParameter"));
+            result.Wait();
+            Assert.AreEqual(JObject.Parse(expectedResult), JObject.Parse(result.Result));
+
+            // Check method can't be used with its actual parameter name
+            result = JsonRpcProcessor.Process(request("arg"));
+            result.Wait();
+            StringAssert.Contains("-32602", result.Result); // check for 'invalid params' error code
+        }
+
         private static void AssertJsonAreEqual(string expectedJson, string actualJson)
         {
             Newtonsoft.Json.Linq.JObject expected = (Newtonsoft.Json.Linq.JObject)Newtonsoft.Json.JsonConvert.DeserializeObject(expectedJson);

--- a/AustinHarris.JsonRpcTestN/Test.cs
+++ b/AustinHarris.JsonRpcTestN/Test.cs
@@ -1869,6 +1869,18 @@ namespace AustinHarris.JsonRpcTestN
             StringAssert.Contains("-32602", result.Result); // check for 'invalid params' error code
         }
 
+        [Test()]
+        public void TestCustomParameterWithNoSpecificName()
+        {
+            Func<string, string> request = (string paramName) => String.Format("{{method:'TestCustomParameterWithNoSpecificName',params:{{ {0}:'some string'}},id:1}}", paramName);
+            string expectedResult = "{\"jsonrpc\":\"2.0\",\"result\":true,\"id\":1}";
+
+            // Check method can be used with its parameter name
+            var result = JsonRpcProcessor.Process(request("arg"));
+            result.Wait();
+            Assert.AreEqual(JObject.Parse(expectedResult), JObject.Parse(result.Result));
+        }
+
         private static void AssertJsonAreEqual(string expectedJson, string actualJson)
         {
             Newtonsoft.Json.Linq.JObject expected = (Newtonsoft.Json.Linq.JObject)Newtonsoft.Json.JsonConvert.DeserializeObject(expectedJson);

--- a/AustinHarris.JsonRpcTestN/service.cs
+++ b/AustinHarris.JsonRpcTestN/service.cs
@@ -73,6 +73,13 @@ namespace AustinHarris.JsonRpcTestN
         }
 
         [JsonRpcMethod]
+        private bool TestCustomParameterName([JsonRpcParam("myCustomParameter")] string arg)
+        {
+            return true;
+        }
+
+
+        [JsonRpcMethod]
         private string StringToRefException(string s, ref JsonRpcException refException)
         {
             refException = new JsonRpcException(-1, "refException worked", null);

--- a/AustinHarris.JsonRpcTestN/service.cs
+++ b/AustinHarris.JsonRpcTestN/service.cs
@@ -78,6 +78,12 @@ namespace AustinHarris.JsonRpcTestN
             return true;
         }
 
+        [JsonRpcMethod]
+        private bool TestCustomParameterWithNoSpecificName([JsonRpcParam] string arg)
+        {
+            return true;
+        }
+
 
         [JsonRpcMethod]
         private string StringToRefException(string s, ref JsonRpcException refException)

--- a/Json-Rpc/Attributes.cs
+++ b/Json-Rpc/Attributes.cs
@@ -24,4 +24,27 @@ namespace AustinHarris.JsonRpc
             get { return jsonMethodName; }
         }
     }
+
+    /// <summary>
+    /// Used to assign JsonRpc parameter name to method argument.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false, AllowMultiple = false)]
+    public sealed class JsonRpcParamAttribute : Attribute
+    {
+        readonly string jsonParamName;
+
+        /// <summary>
+        /// Used to assign JsonRpc parameter name to method argument.
+        /// </summary>
+        /// <param name="jsonParamName">Lets you specify the parameter name as it will be referred to by JsonRpc.</param>
+        public JsonRpcParamAttribute(string jsonParamName = "")
+        {
+            this.jsonParamName = jsonParamName;
+        }
+
+        public string JsonParamName
+        {
+            get { return jsonParamName; }
+        }
+    }
 }

--- a/Json-Rpc/ServiceBinder.cs
+++ b/Json-Rpc/ServiceBinder.cs
@@ -25,12 +25,23 @@
                 List<Type> parameterTypeArray = new List<Type>();
                 for (int i = 0; i < paramzs.Length; i++)
                 {
+                    string paramName;
+                    var paramAttrs = paramzs[i].GetCustomAttributes(typeof(JsonRpcParamAttribute), false);
+                    if (paramAttrs.Length > 0)
+                    {
+                        paramName = ((JsonRpcParamAttribute)paramAttrs[0]).JsonParamName;
+                    }
+                    else
+                    {
+                        paramName = paramzs[i].Name;
+                    }
+
                     // reflection attribute information for optional parameters
                     //http://stackoverflow.com/questions/2421994/invoking-methods-with-optional-parameters-through-reflection
-                    paras.Add(paramzs[i].Name, paramzs[i].ParameterType);
+                    paras.Add(paramName, paramzs[i].ParameterType);
 
                     if (paramzs[i].IsOptional) // if the parameter is an optional, add the default value to our default values dictionary.
-                        defaultValues.Add(paramzs[i].Name, paramzs[i].DefaultValue);
+                        defaultValues.Add(paramName, paramzs[i].DefaultValue);
                 }
 
                 var resType = meth.ReturnType;

--- a/Json-Rpc/ServiceBinder.cs
+++ b/Json-Rpc/ServiceBinder.cs
@@ -30,6 +30,8 @@
                     if (paramAttrs.Length > 0)
                     {
                         paramName = ((JsonRpcParamAttribute)paramAttrs[0]).JsonParamName;
+                        if (string.IsNullOrEmpty(paramName))
+                            paramName = paramzs[i].Name;
                     }
                     else
                     {


### PR DESCRIPTION
Hello, 

This is basically the same as my another pull request to support custom parameter names (https://github.com/Astn/JSON-RPC.NET/pull/51) but with unit test added.
