### PR TITLE
When there were too many arguments you'd get an index out of bounds exception

### DIFF
--- a/AustinHarris.JsonRpcTestN/Test.cs
+++ b/AustinHarris.JsonRpcTestN/Test.cs
@@ -1852,6 +1852,16 @@ namespace AustinHarris.JsonRpcTestN
             Assert.AreEqual(JObject.Parse(expectedResultAfterDestroy), JObject.Parse(result2.Result));
         }
 
+        [Test()]
+        public void TestExtraParameters()
+        {
+            string request = @"{method:'ReturnsDateTime',params:{extra:'mytext'},id:1}";
+            var result = JsonRpcProcessor.Process(request);
+            result.Wait();
+            Assert.IsTrue(result.Result.Contains("error"));
+            Assert.IsTrue(result.Result.Contains("\"code\":-32602"));
+        }
+
         private static void AssertJsonAreEqual(string expectedJson, string actualJson)
         {
             Newtonsoft.Json.Linq.JObject expected = (Newtonsoft.Json.Linq.JObject)Newtonsoft.Json.JsonConvert.DeserializeObject(expectedJson);

--- a/Json-Rpc/Handler.cs
+++ b/Json-Rpc/Handler.cs
@@ -261,7 +261,7 @@
                 //    pCount++;
                 //parameters = new object[pCount];
                 var asDict = jo as IDictionary<string, Newtonsoft.Json.Linq.JToken>;
-                for (int i = 0; i < loopCt; i++)
+                for (int i = 0; i < loopCt && i < metadata.parameters.Length; i++)
                 {
                     if (asDict.ContainsKey(metadata.parameters[i].Name) == false)
                     {


### PR DESCRIPTION
When there were too many arguments you'd get an index out of bounds exception rather than the nicer -32602 error that should be had. This ensures that we don't get an exception when there are too many parameters.