### PR TITLE
Proper handle nested, recursive types for parameters and returns.

### DIFF
--- a/AustinHarris.JsonRpcTestN/Test.cs
+++ b/AustinHarris.JsonRpcTestN/Test.cs
@@ -1862,6 +1862,16 @@ namespace AustinHarris.JsonRpcTestN
             Assert.IsTrue(result.Result.Contains("\"code\":-32602"));
         }
 
+        [Test]
+        public void TestNestedReturnType()
+        {
+            var request = @"{""jsonrpc"":""2.0"",""method"":""TestNestedReturnType"",""id"":1}";
+            var expected = @"{""jsonrpc"":""2.0"",""result"":{""NodeId"":1,""Leafs"":[{""NodeId"":2,""Leafs"":[]},{""NodeId"":3,""Leafs"":[]}]},""id"":1}";
+            var result = JsonRpcProcessor.Process(request);
+            result.Wait();
+            Assert.AreEqual(expected, result.Result);
+        }
+
         private static void AssertJsonAreEqual(string expectedJson, string actualJson)
         {
             Newtonsoft.Json.Linq.JObject expected = (Newtonsoft.Json.Linq.JObject)Newtonsoft.Json.JsonConvert.DeserializeObject(expectedJson);

--- a/AustinHarris.JsonRpcTestN/service.cs
+++ b/AustinHarris.JsonRpcTestN/service.cs
@@ -7,6 +7,13 @@ using System.Text;
 
 namespace AustinHarris.JsonRpcTestN
 {
+    public class TreeNode
+    {
+        public int NodeId { get; set; }
+
+        public IList<TreeNode> Leafs { get; set; }
+    }
+
     public class CalculatorService : JsonRpcService
     {
         [JsonRpcMethod]
@@ -354,5 +361,21 @@ namespace AustinHarris.JsonRpcTestN
             JsonRpcContext.SetException(new JsonRpcException(-27001, "This exception was thrown using: JsonRpcContext.SetException()", null));
             return null;
         }
+
+        [JsonRpcMethod]
+        public TreeNode TestNestedReturnType()
+        {
+            return new TreeNode
+            {
+                NodeId = 1,
+                Leafs =
+                    new[]
+                    {
+                        new TreeNode {NodeId = 2, Leafs = new List<TreeNode>()},
+                        new TreeNode {NodeId = 3, Leafs = new List<TreeNode>()}
+                    }
+            };
+        }
+
     }
 }


### PR DESCRIPTION
This is about nested and recursive parameter or return types.

If the JsonRpcMethod declares like:
```csharp
[JsonRpcMethod]
public TreeNode MyMightyMethod()
{ ... }
```
where TreeNode declares like:
```csharp
public class TreeNode
{
    public Payload Data { get; set; }
    public IList<TreeNode> Leafs { get; set; }
}
```
SMD.getTypeRecursive recuses infinite until there's no more stack available. 
This fix it, by first looking up whether any type is already known to the SMD and using its index rather then calling getTypeRecursive. This requires adding the type to SMD even if its not fully analyzed. 