### PR TITLE
Simplify a few portions of the code.

### DIFF
--- a/AustinHarris.JsonRpc.AspNet/AustinHarris.JsonRpc.AspNet.csproj
+++ b/AustinHarris.JsonRpc.AspNet/AustinHarris.JsonRpc.AspNet.csproj
@@ -36,8 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/AustinHarris.JsonRpc.AspNet/packages.config
+++ b/AustinHarris.JsonRpc.AspNet/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
 </packages>

--- a/AustinHarris.JsonRpc.sln
+++ b/AustinHarris.JsonRpc.sln
@@ -1,12 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 2013
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BBFBBA8A-2F75-422C-ACCD-D05A6EF7244C}"
 	ProjectSection(SolutionItems) = preProject
 		AustinHarris.JsonRpc.vsmdi = AustinHarris.JsonRpc.vsmdi
 		Local.testsettings = Local.testsettings
+		Performance1.psess = Performance1.psess
 		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
 	EndProjectSection
 EndProject
@@ -44,22 +45,18 @@ Global
 		{24FC1A2A-0BC3-43A7-9BFE-B628C2C4A307}.Release|Mixed Platforms.Build.0 = Release|x86
 		{24FC1A2A-0BC3-43A7-9BFE-B628C2C4A307}.Release|x86.ActiveCfg = Release|x86
 		{24FC1A2A-0BC3-43A7-9BFE-B628C2C4A307}.Release|x86.Build.0 = Release|x86
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|ARM.ActiveCfg = Debug|Any CPU
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|ARM.Build.0 = Debug|Any CPU
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|x86.ActiveCfg = Debug|x86
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|x86.Build.0 = Debug|x86
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|ARM.ActiveCfg = Release|Any CPU
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|ARM.Build.0 = Release|Any CPU
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|x86.ActiveCfg = Release|x86
-		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|x86.Build.0 = Release|x86
+		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Release|ARM.ActiveCfg = Release|Any CPU
+		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Release|x86.ActiveCfg = Release|Any CPU
 		{8569B076-5A8B-4D6A-B75D-EF75A390AA5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8569B076-5A8B-4D6A-B75D-EF75A390AA5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8569B076-5A8B-4D6A-B75D-EF75A390AA5F}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -76,20 +73,22 @@ Global
 		{8569B076-5A8B-4D6A-B75D-EF75A390AA5F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{8569B076-5A8B-4D6A-B75D-EF75A390AA5F}.Release|x86.ActiveCfg = Release|Any CPU
 		{8569B076-5A8B-4D6A-B75D-EF75A390AA5F}.Release|x86.Build.0 = Release|Any CPU
-		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Debug|ARM.ActiveCfg = Debug|Any CPU
-		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Release|ARM.ActiveCfg = Release|Any CPU
-		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB}.Release|x86.ActiveCfg = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|ARM.Build.0 = Debug|Any CPU
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|x86.ActiveCfg = Debug|x86
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Debug|x86.Build.0 = Debug|x86
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|ARM.ActiveCfg = Release|Any CPU
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|ARM.Build.0 = Release|Any CPU
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|x86.ActiveCfg = Release|x86
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AustinHarris.JsonRpcTestN/AustinHarris.JsonRpcTestN.csproj
+++ b/AustinHarris.JsonRpcTestN/AustinHarris.JsonRpcTestN.csproj
@@ -30,8 +30,8 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">

--- a/AustinHarris.JsonRpcTestN/Test.cs
+++ b/AustinHarris.JsonRpcTestN/Test.cs
@@ -64,14 +64,11 @@ namespace AustinHarris.JsonRpcTestN
         public void TestCanCreateAndRemoveSession()
         {
             var h = JsonRpc.Handler.GetSessionHandler("this one");
-
-            h.Register("workie", new Func<string, string>(x => "workie ... " + x));
-
             var metadata = new System.Collections.Generic.List<Tuple<string, Type>> {
                 Tuple.Create ("sooper", typeof(string)),
                 Tuple.Create ("returns", typeof(string))
             }.ToDictionary(x => x.Item1, x => x.Item2);
-            h.MetaData.AddService("workie", metadata, new System.Collections.Generic.Dictionary<string, object>());
+            h.MetaData.AddService("workie", metadata, new System.Collections.Generic.Dictionary<string, object>(),new Func<string, string>(x => "workie ... " + x));
 
             string request = @"{method:'workie',params:{'sooper':'good'},id:1}";
             string expectedResult = "{\"jsonrpc\":\"2.0\",\"result\":\"workie ... good\",\"id\":1}";
@@ -1582,13 +1579,11 @@ namespace AustinHarris.JsonRpcTestN
             PreProcessHandlerLocal preHandler = new PreProcessHandlerLocal();
             h.SetPreProcessHandler(new PreProcessHandler(preHandler.PreProcess));
 
-            h.Register("workie", new Func<string, string>(x => "workie ... " + x));
-
             var metadata = new System.Collections.Generic.List<Tuple<string, Type>> {
                 Tuple.Create ("sooper", typeof(string)),
                 Tuple.Create ("returns", typeof(string))
             }.ToDictionary(x => x.Item1, x => x.Item2);
-            h.MetaData.AddService("workie", metadata, new System.Collections.Generic.Dictionary<string, object>());
+            h.MetaData.AddService("workie", metadata, new System.Collections.Generic.Dictionary<string, object>(),new Func<string, string>(x => "workie ... " + x));
 
             string request = @"{method:'workie',params:{'sooper':'good'},id:1}";
             string expectedResult = "{\"jsonrpc\":\"2.0\",\"result\":\"workie ... good\",\"id\":1}";
@@ -1824,13 +1819,11 @@ namespace AustinHarris.JsonRpcTestN
             PostProcessHandlerLocal postHandler = new PostProcessHandlerLocal(false);
             h.SetPostProcessHandler(new PostProcessHandler(postHandler.PostProcess));
 
-            h.Register("workie", new Func<string, string>(x => "workie ... " + x));
-
             var metadata = new System.Collections.Generic.List<Tuple<string, Type>> {
                 Tuple.Create ("sooper", typeof(string)),
                 Tuple.Create ("returns", typeof(string))
             }.ToDictionary(x => x.Item1, x => x.Item2);
-            h.MetaData.AddService("workie", metadata, new System.Collections.Generic.Dictionary<string, object>());
+            h.MetaData.AddService("workie", metadata, new System.Collections.Generic.Dictionary<string, object>(), new Func<string, string>(x => "workie ... " + x));
 
             string request = @"{method:'workie',params:{'sooper':'good'},id:1}";
             string expectedResult = "{\"jsonrpc\":\"2.0\",\"result\":\"workie ... good\",\"id\":1}";

--- a/AustinHarris.JsonRpcTestN/packages.config
+++ b/AustinHarris.JsonRpcTestN/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/Json-Rpc/AustinHarris.JsonRpc.csproj
+++ b/Json-Rpc/AustinHarris.JsonRpc.csproj
@@ -71,11 +71,14 @@
     <Compile Include="SMDService.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
@@ -92,7 +95,4 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
 </Project>

--- a/Json-Rpc/Handler.cs
+++ b/Json-Rpc/Handler.cs
@@ -34,7 +34,6 @@
         {
             SessionId = sessionId;
             this.MetaData = new SMD();
-            this.Handlers = new Dictionary<string, Delegate>();
         }
 
         #endregion
@@ -74,7 +73,6 @@
         {
             Handler h;
             _sessionHandlers.TryRemove(sessionId, out h);
-            h.Handlers.Clear();
             h.MetaData.Services.Clear();
         }
         /// <summary>
@@ -142,7 +140,6 @@
         private AustinHarris.JsonRpc.PostProcessHandler externalPostProcessingHandler;
         private Func<JsonRequest, JsonRpcException, JsonRpcException> externalErrorHandler;
         private Func<string, JsonRpcException, JsonRpcException> parseErrorHandler;
-        private Dictionary<string, Delegate> Handlers { get; set; }
         #endregion
 
         /// <summary>
@@ -154,27 +151,8 @@
 
         #region Public Methods
 
-        /// <summary>
-        /// Registers a jsonRpc method name (key) to be mapped to a specific function
-        /// </summary>
-        /// <param name="key">The Method as it will be called from JsonRpc</param>
-        /// <param name="handle">The method that will be invoked</param>
-        /// <returns></returns>
-        public bool Register(string key, Delegate handle)
-        {
-            var result = false;
-
-            if (!this.Handlers.ContainsKey(key))
-            {
-                this.Handlers.Add(key, handle);
-            }
-
-            return result;
-        }
-
         public void UnRegister(string key)
         {
-            this.Handlers.Remove(key);
             MetaData.Services.Remove(key);
         }
 
@@ -203,10 +181,13 @@
 
             SMDService metadata = null;
             Delegate handle = null;
-            var haveDelegate = this.Handlers.TryGetValue(Rpc.Method, out handle);
             var haveMetadata = this.MetaData.Services.TryGetValue(Rpc.Method, out metadata);
+            if (haveMetadata)
+            {
+                handle = metadata.dele; 
+            }
 
-            if (haveDelegate == false || haveMetadata == false || metadata == null || handle == null)
+            if (haveMetadata == false || metadata == null)
             {
                 JsonResponse response = new JsonResponse()
                 {

--- a/Json-Rpc/JsonRpcProcessor.cs
+++ b/Json-Rpc/JsonRpcProcessor.cs
@@ -119,12 +119,7 @@ namespace AustinHarris.JsonRpc
 
         public static void Process(JsonRpcStateAsync async, object context = null)
         {
-            Task.Factory.StartNew((_async) =>
-            {
-                var tuple = (Tuple<JsonRpcStateAsync, object>)_async;
-                ProcessJsonRpcState(tuple.Item1, tuple.Item2);
-            }, new Tuple<JsonRpcStateAsync, object>(async, context));
-
+            Process(Handler.DefaultSessionId(), async, context);
         }
 
         public static void Process(string sessionId, JsonRpcStateAsync async, object context = null)
@@ -132,18 +127,10 @@ namespace AustinHarris.JsonRpc
             var t = Task.Factory.StartNew((_async) =>
             {
                 var i = (Tuple<string, JsonRpcStateAsync, object>)_async;
-                ProcessJsonRpcState(i.Item1, i.Item2, i.Item3);
+                async.Result = ProcessInternal(i.Item1, i.Item2.JsonRpc, i.Item3);
+                async.SetCompleted();
             }, new Tuple<string, JsonRpcStateAsync, object>(sessionId, async, context));
 
-        }
-        internal static void ProcessJsonRpcState(JsonRpcStateAsync async, object jsonRpcContext = null)
-        {
-            ProcessJsonRpcState(Handler.DefaultSessionId(), async, jsonRpcContext);
-        }
-        internal static void ProcessJsonRpcState(string sessionId, JsonRpcStateAsync async, object jsonRpcContext = null)
-        {
-            async.Result = ProcessInternal(sessionId, async.JsonRpc, jsonRpcContext);
-            async.SetCompleted();
         }
 
         public static Task<string> Process(string jsonRpc, object context = null)

--- a/Json-Rpc/SMDService.cs
+++ b/Json-Rpc/SMDService.cs
@@ -34,9 +34,9 @@ namespace AustinHarris.JsonRpc
             TypeHashes = new List<string>();
 	    }
 
-        public void AddService(string method, Dictionary<string,Type> parameters, Dictionary<string, object> defaultValues)
+        public void AddService(string method, Dictionary<string,Type> parameters, Dictionary<string, object> defaultValues, Delegate dele)
         {
-            var newService = new SMDService(transport,"JSON-RPC-2.0",parameters, defaultValues);
+            var newService = new SMDService(transport,"JSON-RPC-2.0",parameters, defaultValues, dele);
             Services.Add(method,newService);
         }
 
@@ -64,6 +64,7 @@ namespace AustinHarris.JsonRpc
 
     public class SMDService
     {
+        public Delegate dele;
         /// <summary>
         /// Defines a service method http://dojotoolkit.org/reference-guide/1.8/dojox/rpc/smd.html
         /// </summary>
@@ -71,9 +72,10 @@ namespace AustinHarris.JsonRpc
         /// <param name="envelope">URL, PATH, JSON, JSON-RPC-1.0, JSON-RPC-1.1, JSON-RPC-2.0</param>
         /// <param name="parameters"></param>
         /// <param name="defaultValues"></param>
-        public SMDService(string transport, string envelope, Dictionary<string, Type> parameters, Dictionary<string, object> defaultValues )
+        public SMDService(string transport, string envelope, Dictionary<string, Type> parameters, Dictionary<string, object> defaultValues, Delegate dele)
         {
             // TODO: Complete member initialization
+            this.dele = dele;
             this.transport = transport;
             this.envelope = envelope;
             this.parameters = new SMDAdditionalParameters[parameters.Count-1]; // last param is return type similar to Func<,>

--- a/Json-Rpc/ServiceBinder.cs
+++ b/Json-Rpc/ServiceBinder.cs
@@ -12,7 +12,6 @@
         {
             var instance = serviceFactory();
             var item = instance.GetType(); // var item = typeof(T);
-            var regMethod = typeof(Handler).GetMethod("Register");
 
             var methods = item.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(m => m.GetCustomAttributes(typeof(JsonRpcMethodAttribute), false).Length > 0);
             foreach (var meth in methods)
@@ -42,8 +41,7 @@
                     var methodName = handlerAttribute.JsonMethodName == string.Empty ? meth.Name : handlerAttribute.JsonMethodName;
                     var newDel = Delegate.CreateDelegate(System.Linq.Expressions.Expression.GetDelegateType(paras.Values.ToArray()), instance /*Need to add support for other methods outside of this instance*/, meth);
                     var handlerSession = Handler.GetSessionHandler(sessionID);
-                    regMethod.Invoke(handlerSession, new object[] { methodName, newDel });
-                    handlerSession.MetaData.AddService(methodName, paras, defaultValues);
+                    handlerSession.MetaData.AddService(methodName, paras, defaultValues, newDel);
                 }
             }
         }

--- a/Json-Rpc/packages.config
+++ b/Json-Rpc/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
 </packages>

--- a/TestServer_Console/TestServer_Console.csproj
+++ b/TestServer_Console/TestServer_Console.csproj
@@ -50,8 +50,8 @@
     <Optimize>false</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -75,6 +75,9 @@
       <Project>{24FC1A2A-0BC3-43A7-9BFE-B628C2C4A307}</Project>
       <Name>AustinHarris.JsonRpc</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/TestServer_Console/packages.config
+++ b/TestServer_Console/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net40-Client" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40-Client" />
 </packages>

--- a/TestServer_Console/service.cs
+++ b/TestServer_Console/service.cs
@@ -37,5 +37,95 @@ namespace TestServer_Console
         {
             return x;
         }
+
+        [JsonRpcMethod]
+        private double add_1(double l, double r)
+        {
+            return l + r;
+        }
+
+        [JsonRpcMethod]
+        private int addInt_1(int l, int r)
+        {
+            return l + r;
+        }
+
+        [JsonRpcMethod]
+        public float? NullableFloatToNullableFloat_1(float? a)
+        {
+            return a;
+        }
+
+        [JsonRpcMethod]
+        public decimal? Test2_1(decimal x)
+        {
+            return x;
+        }
+
+        [JsonRpcMethod]
+        public string StringMe_1(string x)
+        {
+            return x;
+        }
+
+        [JsonRpcMethod]
+        private double add_2(double l, double r)
+        {
+            return l + r;
+        }
+
+        [JsonRpcMethod]
+        private int addInt_2(int l, int r)
+        {
+            return l + r;
+        }
+
+        [JsonRpcMethod]
+        public float? NullableFloatToNullableFloat_2(float? a)
+        {
+            return a;
+        }
+
+        [JsonRpcMethod]
+        public decimal? Test2_2(decimal x)
+        {
+            return x;
+        }
+
+        [JsonRpcMethod]
+        public string StringMe_2(string x)
+        {
+            return x;
+        }
+
+        [JsonRpcMethod]
+        private double add_3(double l, double r)
+        {
+            return l + r;
+        }
+
+        [JsonRpcMethod]
+        private int addInt_3(int l, int r)
+        {
+            return l + r;
+        }
+
+        [JsonRpcMethod]
+        public float? NullableFloatToNullableFloat_3(float? a)
+        {
+            return a;
+        }
+
+        [JsonRpcMethod]
+        public decimal? Test2_3(decimal x)
+        {
+            return x;
+        }
+
+        [JsonRpcMethod]
+        public string StringMe_3(string x)
+        {
+            return x;
+        }
     }
 }


### PR DESCRIPTION
Bump to Newtonsoft 9.
Bump the SLN to visual studio 2013.

No longer call register and then setup the metadata on SMD. Just add the delegate to the SMDservice.
This removes to need to have a dictionary of delegates.

This does break compatibility for anyone who was manually registering services. As Handler.register has been removed. And Metadata.AddService now requires the delegate that was previously passed to Handler.register.

I also added a few extra services to the test console to slightly better exercise the service lookup logic.