### PR TITLE
Notification null result handling

### DIFF
--- a/AustinHarris.JsonRpcTestN/Test.cs
+++ b/AustinHarris.JsonRpcTestN/Test.cs
@@ -140,7 +140,7 @@ namespace AustinHarris.JsonRpcTestN
         public void NullableFloatToNullableFloat2()
         {
             string request = @"{method:'NullableFloatToNullableFloat',params:[null],id:1}";
-            string expectedResult = "{\"jsonrpc\":\"2.0\",\"id\":1}";
+            string expectedResult = "{\"jsonrpc\":\"2.0\",\"result\":null,\"id\":1}";
             var result = JsonRpcProcessor.Process(request);
             result.Wait();
             Assert.AreEqual(result.Result, expectedResult);
@@ -1435,6 +1435,17 @@ namespace AustinHarris.JsonRpcTestN
             result.Wait();
 
             Assert.IsTrue(string.IsNullOrEmpty(result.Result));
+        }
+
+
+        [Test()]
+        public void TestNotificationVoidResult()
+        {
+            var secondRequest = @"{""jsonrpc"":""2.0"",""method"":""Notify"",""params"":[""Hello World!""], ""id"":73}";
+            var result = JsonRpcProcessor.Process(secondRequest);
+            result.Wait();
+            Console.WriteLine(result.Result);
+            Assert.IsTrue(result.Result.Contains("result"), "Json Rpc 2.0 Spec - 'result' - This member is REQUIRED on success. A function that returns void should have the result property included even though the value may be null.");
         }
 
         [Test()]

--- a/Json-Rpc/JsonRpcProcessor.cs
+++ b/Json-Rpc/JsonRpcProcessor.cs
@@ -209,6 +209,14 @@ namespace AustinHarris.JsonRpc
                 var idx = 0;
                 foreach (var resp in batch.Where(x => x.Item2.Id != null || x.Item2.Error != null))
                 {
+                    if (resp.Item2.Result == null && resp.Item2.Error == null)
+                    {
+                        // Per json rpc 2.0 spec
+                        // result : This member is REQUIRED on success.
+                        // This member MUST NOT exist if there was an error invoking the method.    
+                        // Either the result member or error member MUST be included, but both members MUST NOT be included.
+                        resp.Item2.Result = new Newtonsoft.Json.Linq.JValue((Object)null);
+                    }
                     responses[idx++] = JsonConvert.SerializeObject(resp.Item2);
                 }
 


### PR DESCRIPTION
This fixes #66 
The result property was missing when calling functions with a void return type. We now correctly follow the spec in regards to ensuring that the result property is present when the invocation is successful.
