### PR TITLE
Add .Net Standard support

### DIFF
--- a/AustinHarris.JsonRpc.Standard/Attributes.cs
+++ b/AustinHarris.JsonRpc.Standard/Attributes.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace AustinHarris.JsonRpc
+{
+    /// <summary>
+    /// Required to expose a method to the JsonRpc service.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+    public sealed class JsonRpcMethodAttribute : Attribute
+    {
+        readonly string jsonMethodName;
+
+        /// <summary>
+        /// Required to expose a method to the JsonRpc service.
+        /// </summary>
+        /// <param name="jsonMethodName">Lets you specify the method name as it will be referred to by JsonRpc.</param>
+        public JsonRpcMethodAttribute(string jsonMethodName = "")
+        {
+            this.jsonMethodName = jsonMethodName;
+        }
+
+        public string JsonMethodName
+        {
+            get { return jsonMethodName; }
+        }
+    }
+
+    /// <summary>
+    /// Used to assign JsonRpc parameter name to method argument.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false, AllowMultiple = false)]
+    public sealed class JsonRpcParamAttribute : Attribute
+    {
+        readonly string jsonParamName;
+
+        /// <summary>
+        /// Used to assign JsonRpc parameter name to method argument.
+        /// </summary>
+        /// <param name="jsonParamName">Lets you specify the parameter name as it will be referred to by JsonRpc.</param>
+        public JsonRpcParamAttribute(string jsonParamName = "")
+        {
+            this.jsonParamName = jsonParamName;
+        }
+
+        public string JsonParamName
+        {
+            get { return jsonParamName; }
+        }
+    }
+}

--- a/AustinHarris.JsonRpc.Standard/AustinHarris.JsonRpc.Standard.csproj
+++ b/AustinHarris.JsonRpc.Standard/AustinHarris.JsonRpc.Standard.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/AustinHarris.JsonRpc.Standard/Client/InProcessJsonRpcClient.cs
+++ b/AustinHarris.JsonRpc.Standard/Client/InProcessJsonRpcClient.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace AustinHarris.JsonRpc.Client
+{
+    public class InProcessClient
+    {
+        /// <summary>
+        /// Simple wrapper around JsonRpcProcessor.Process
+        /// </summary>
+        /// <param name="jsonrpc"></param>
+        /// <returns></returns>        
+        /// 
+        [Obsolete("You can now use JsonRpcProcessor.Process directly")]
+        public static Task<string> Invoke(string jsonrpc)
+        {
+            return JsonRpcProcessor.Process(jsonrpc);
+        }
+    }
+}

--- a/AustinHarris.JsonRpc.Standard/Config.cs
+++ b/AustinHarris.JsonRpc.Standard/Config.cs
@@ -1,0 +1,103 @@
+﻿using System;
+
+namespace AustinHarris.JsonRpc
+{
+    /// <summary>
+    /// The PreProcessHandler is called after the request has been parsed and prior to calling the associated method on the JsonRpcService.
+    /// If any non-null result is returned from the PreProcessHandler, the operation is aborted and the error is returned to the caller.
+    /// </summary>
+    /// <param name="request">The jsonRpc Request that is pending processing.</param>
+    /// <param name="context">The context associated with this request</param>
+    /// <returns>Any non-null result causes the operation to be aborted, and the JsonRpcException is returned to the caller.</returns>
+    public delegate JsonRpcException PreProcessHandler(JsonRequest request, object context);
+    /// <summary>
+    /// The PostProcessHandler is called after the response has been created and prior to returning the data to the caller.
+    /// If any non-null result is returned from the PostProcessHandler, the current return value is discared and the new return value used
+    /// in preference.
+    /// </summary>
+    /// <param name="request">The jsonRpc Request that has been processed.</param>
+    /// <param name="response">The jsonRpc Response that has been created.</param>
+    /// <param name="context">The context associated with this request/response pair</param>
+    /// <returns>Any non-null result causes the result to be discarded and the JsonRpcException is returned to the caller.</returns>
+    public delegate JsonRpcException PostProcessHandler(JsonRequest request, JsonResponse response, object context);
+
+    /// <summary>
+    /// Global configurations for JsonRpc
+    /// </summary>
+    public static class Config
+    {
+        /// <summary>
+        /// Sets the the PreProcessing Handler on the default session.
+        /// </summary>
+        /// <param name="handler"></param>
+        public static void SetPreProcessHandler(PreProcessHandler handler)
+        {
+            Handler.DefaultHandler.SetPreProcessHandler(handler);
+        }
+
+        /// <summary>
+        /// Sets the the PostProcessing Handler on the default session.
+        /// </summary>
+        /// <param name="handler"></param>
+        public static void SetPostProcessHandler(PostProcessHandler handler)
+        {
+            Handler.DefaultHandler.SetPostProcessHandler(handler);
+        }
+
+        /// <summary>
+        /// Sets the PreProcessing Handler on a specific session
+        /// </summary>
+        /// <param name="sessionId"></param>
+        /// <param name="handler"></param>
+        public static void SetBeforeProcessHandler(string sessionId, PreProcessHandler handler)
+        {
+            Handler.GetSessionHandler(sessionId).SetPreProcessHandler(handler);
+        }
+
+        /// <summary>
+        /// For exceptions thrown after the routed method has been called.
+        /// Allows you to specify an error handler that will be invoked prior to returning the JsonResponse to the client.
+        /// You are able to modify the error that is returned inside the provided handler.
+        /// </summary>
+        /// <param name="handler"></param>
+        public static void SetErrorHandler(Func<JsonRequest, JsonRpcException, JsonRpcException> handler)
+        {
+            Handler.DefaultHandler.SetErrorHandler(handler);
+        }
+
+        /// <summary>
+        /// For exceptions thrown after the routed method has been called.
+        /// Allows you to specify an error handler that will be invoked prior to returning the JsonResponse to the client.
+        /// You are able to modify the error that is returned inside the provided handler. 
+        /// </summary>
+        /// <param name="sessionId"></param>
+        /// <param name="handler"></param>
+        public static void SetErrorHandler(string sessionId, Func<JsonRequest, JsonRpcException, JsonRpcException> handler)
+        {
+            Handler.GetSessionHandler(sessionId).SetErrorHandler(handler);
+        }
+
+        /// <summary>
+        /// For exceptions thrown during parsing and prior to a routed method being called.
+        /// Allows you to specify an error handler that will be invoked prior to returning the JsonResponse to the client.
+        /// You are able to modify the error that is returned inside the provided handler.
+        /// </summary>
+        /// <param name="handler"></param>
+        public static void SetParseErrorHandler(Func<string,JsonRpcException,JsonRpcException> handler)
+        {
+            Handler.DefaultHandler.SetParseErrorHandler(handler);
+        }
+
+        /// <summary>
+        /// For exceptions thrown during parsing and prior to a routed method being called.
+        /// Allows you to specify an error handler that will be invoked prior to returning the JsonResponse to the client.
+        /// You are able to modify the error that is returned inside the provided handler. 
+        /// </summary>
+        /// <param name="sessionId"></param>
+        /// <param name="handler"></param>
+        public static void SetParseErrorHandler(string sessionId, Func<string, JsonRpcException, JsonRpcException> handler)
+        {
+            Handler.GetSessionHandler(sessionId).SetParseErrorHandler(handler);
+        }
+    }
+}

--- a/AustinHarris.JsonRpc.Standard/Handler.cs
+++ b/AustinHarris.JsonRpc.Standard/Handler.cs
@@ -1,0 +1,512 @@
+﻿namespace AustinHarris.JsonRpc
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Newtonsoft.Json;
+    using System.Collections.Concurrent;
+    using Newtonsoft.Json.Linq;
+    using System.Threading;
+
+    public class Handler
+    {
+        #region Members
+        private const string Name_of_JSONRPCEXCEPTION = "JsonRpcException&";
+        private static int _sessionHandlerMasterVersion = 1;
+        [ThreadStatic]
+        private static Dictionary<string, Handler> _sessionHandlersLocal;
+        [ThreadStatic]
+        private static int _sessionHandlerLocalVersion = 0;
+        private static ConcurrentDictionary<string, Handler> _sessionHandlersMaster;
+        
+        private static volatile string _defaultSessionId;
+        #endregion
+
+        #region Constructors
+
+        static Handler()
+        {
+            //current = new Handler(Guid.NewGuid().ToString());
+            _defaultSessionId = Guid.NewGuid().ToString();
+            _sessionHandlersMaster = new ConcurrentDictionary<string, Handler>();
+            _sessionHandlersMaster[_defaultSessionId] = new Handler(_defaultSessionId);
+        }
+
+        private Handler(string sessionId)
+        {
+            SessionId = sessionId;
+            this.MetaData = new SMD();
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns the SessionID of the default session
+        /// </summary>
+        /// <returns></returns>
+        public static string DefaultSessionId() { return _defaultSessionId; }
+
+        /// <summary>
+        /// Gets a specific session
+        /// </summary>
+        /// <param name="sessionId">The sessionId of the handler you want to retrieve.</param>
+        /// <returns></returns>
+        public static Handler GetSessionHandler(string sessionId)
+        {
+            if (_sessionHandlerMasterVersion != _sessionHandlerLocalVersion)
+            {
+                _sessionHandlersLocal = new Dictionary<string, Handler>(_sessionHandlersMaster);
+                _sessionHandlerLocalVersion = _sessionHandlerMasterVersion;
+            }
+            if (_sessionHandlersLocal.ContainsKey(sessionId))
+            {
+                return _sessionHandlersLocal[sessionId];
+            }
+            Interlocked.Increment(ref _sessionHandlerMasterVersion);
+            return _sessionHandlersMaster.GetOrAdd(sessionId, new Handler(sessionId));
+        }
+
+        /// <summary>
+        /// gets the default session
+        /// </summary>
+        /// <returns>The default Session Handler</returns>
+        public static Handler GetSessionHandler()
+        {
+            return GetSessionHandler(_defaultSessionId);
+        }
+
+        /// <summary>
+        /// Removes and clears the Handler with the specific sessionID from the registry of Handlers
+        /// </summary>
+        /// <param name="sessionId"></param>
+        public static void DestroySession(string sessionId)
+        {
+            Handler h;
+            _sessionHandlersMaster.TryRemove(sessionId, out h);
+            Interlocked.Increment(ref _sessionHandlerMasterVersion);
+            h.MetaData.Services.Clear();
+        }
+        /// <summary>
+        /// Removes and clears the current Handler from the registry of Handlers
+        /// </summary>
+        public void Destroy()
+        {
+            DestroySession(SessionId);
+        }
+
+        /// <summary>
+        /// Gets the default session handler
+        /// </summary>
+        public static Handler DefaultHandler { get { return GetSessionHandler(_defaultSessionId); } }
+
+        /// <summary>
+        /// The sessionID of this Handler
+        /// </summary>
+        public string SessionId { get; private set; }
+
+        /// <summary>
+        /// Provides access to a context specific to each JsonRpc method invocation.
+        /// Warning: Must be called from within the execution context of the jsonRpc Method to return the context
+        /// </summary>
+        /// <returns></returns>
+        public static object RpcContext()
+        {
+            return __currentRpcContext;
+        }
+
+        [ThreadStatic]
+        static JsonRpcException __currentRpcException;
+        /// <summary>
+        /// Allows you to set the exception used in in the JsonRpc response.
+        /// Warning: Must be called from the same thread as the jsonRpc method.
+        /// </summary>
+        /// <param name="exception"></param>
+        public static void RpcSetException(JsonRpcException exception)
+        {
+            __currentRpcException = exception;
+        }
+        public static JsonRpcException RpcGetAndRemoveRpcException()
+        {
+            var ex = __currentRpcException;
+            __currentRpcException = null ;
+            return ex;
+        }
+
+        private AustinHarris.JsonRpc.PreProcessHandler externalPreProcessingHandler;
+        private AustinHarris.JsonRpc.PostProcessHandler externalPostProcessingHandler;
+        private Func<JsonRequest, JsonRpcException, JsonRpcException> externalErrorHandler;
+        private Func<string, JsonRpcException, JsonRpcException> parseErrorHandler;
+        #endregion
+
+        /// <summary>
+        /// This metadata contains all the types and mappings of all the methods in this handler. Warning: Modifying this directly could cause your handler to no longer function. 
+        /// </summary>
+        public SMD MetaData { get; set; }
+
+        #region Public Methods
+
+        /// <summary>
+        /// Allows you to register all the functions on a Pojo Type that have been attributed as [JsonRpcMethod] to the specified sessionId
+        /// </summary>
+        /// <param name="sessionID">The session to register against</param>
+        /// <param name="instance">The instance containing JsonRpcMethods to register</param>
+        public static void RegisterInstance(string sessionID, object instance)
+        {
+            ServiceBinder.BindService(sessionID, instance);
+        }
+
+        /// <summary>
+        /// Allows you to register any function, lambda, etc even when not attributed with JsonRpcMethod.
+        /// Requires you to specify all types and defaults
+        /// </summary>
+        /// <param name="methodName">The method name that will map to the registered function</param>
+        /// <param name="parameterNameTypeMapping">The parameter names and types that will be positionally bound to the function</param>
+        /// <param name="parameterNameDefaultValueMapping">Optional default values for parameters</param>
+        /// <param name="implementation">A reference to the Function</param>
+        public void RegisterFuction(string methodName, Dictionary<string, Type> parameterNameTypeMapping, Dictionary<string, object> parameterNameDefaultValueMapping, Delegate implementation)
+        {
+            MetaData.AddService(methodName, parameterNameTypeMapping, parameterNameDefaultValueMapping, implementation);
+        }
+
+        public void UnRegisterFunction(string methodName)
+        {
+            MetaData.Services.Remove(methodName);
+        }
+
+        public void SetPreProcessHandler(AustinHarris.JsonRpc.PreProcessHandler handler)
+        {
+            externalPreProcessingHandler = handler;
+        }
+
+        public void SetPostProcessHandler(AustinHarris.JsonRpc.PostProcessHandler handler)
+        {
+            externalPostProcessingHandler = handler;
+        }
+
+        /// <summary>
+        /// Invokes a method to handle a JsonRpc request.
+        /// </summary>
+        /// <param name="Rpc">JsonRpc Request to be processed</param>
+        /// <param name="RpcContext">Optional context that will be available from within the jsonRpcMethod.</param>
+        /// <returns></returns>
+        public JsonResponse Handle(JsonRequest Rpc, Object RpcContext = null)
+        {
+            AddRpcContext(RpcContext);
+
+            var preProcessingException = PreProcess(Rpc, RpcContext);
+            if (preProcessingException != null)
+            {
+                JsonResponse response = new JsonResponse()
+                {
+                    Error = preProcessingException,
+                    Id = Rpc.Id
+                };
+                //callback is called - if it is empty then nothing will be done
+                //return response always- if callback is empty or not
+                return PostProcess(Rpc, response, RpcContext);
+            }
+
+            SMDService metadata = null;
+            Delegate handle = null;
+            if (this.MetaData.Services.TryGetValue(Rpc.Method, out metadata))
+            {
+                handle = metadata.dele; 
+            } else if (metadata == null)
+            {
+                JsonResponse response = new JsonResponse()
+                {
+                    Result = null,
+                    Error = new JsonRpcException(-32601, "Method not found", "The method does not exist / is not available."),
+                    Id = Rpc.Id
+                };
+                return PostProcess(Rpc, response, RpcContext);
+            }
+
+            object[] parameters = null;
+            bool expectsRefException = false;
+            var metaDataParamCount = metadata.parameters.Count(x => x != null);
+
+            
+            var loopCt = 0;
+            var getCount = Rpc.Params as ICollection;
+            if (getCount != null)
+            {
+                loopCt = getCount.Count;
+            }
+
+            var paramCount = loopCt;
+            if (paramCount == metaDataParamCount - 1 && metadata.parameters[metaDataParamCount - 1].ObjectType.Name.Equals(Name_of_JSONRPCEXCEPTION))
+            {
+                paramCount++;
+                expectsRefException = true;
+            }
+            parameters = new object[paramCount];
+
+            if (Rpc.Params is Newtonsoft.Json.Linq.JArray)
+            {
+                var jarr = ((Newtonsoft.Json.Linq.JArray)Rpc.Params);
+                for (int i = 0; i < loopCt; i++)
+                {
+                    parameters[i] = CleanUpParameter(jarr[i], metadata.parameters[i]);
+                }
+            }
+            else if (Rpc.Params is Newtonsoft.Json.Linq.JObject)
+            {
+                var asDict = Rpc.Params as IDictionary<string, Newtonsoft.Json.Linq.JToken>;
+                for (int i = 0; i < loopCt && i < metadata.parameters.Length; i++)
+                {
+                    if (asDict.ContainsKey(metadata.parameters[i].Name) == true)
+                    {
+                        parameters[i] = CleanUpParameter(asDict[metadata.parameters[i].Name], metadata.parameters[i]);
+                        continue;
+                    }
+                    else
+                    {
+                        JsonResponse response = new JsonResponse()
+                        {
+                            Error = ProcessException(Rpc,
+                            new JsonRpcException(-32602,
+                                "Invalid params",
+                                string.Format("Named parameter '{0}' was not present.",
+                                                metadata.parameters[i].Name)
+                                )),
+                            Id = Rpc.Id
+                        };
+                        return PostProcess(Rpc, response, RpcContext);
+                    }
+                }
+            }
+
+            // Optional Parameter support
+            // check if we still miss parameters compared to metadata which may include optional parameters.
+            // if the rpc-call didn't supply a value for an optional parameter, we should be assinging the default value of it.
+            if (parameters.Length < metaDataParamCount && metadata.defaultValues.Length > 0) // rpc call didn't set values for all optional parameters, so we need to assign the default values for them.
+            {
+                var suppliedParamsCount = parameters.Length; // the index we should start storing default values of optional parameters.
+                var missingParamsCount = metaDataParamCount - parameters.Length; // the amount of optional parameters without a value set by rpc-call.
+                Array.Resize(ref parameters, parameters.Length + missingParamsCount); // resize the array to include all optional parameters.
+
+                for (int paramIndex = parameters.Length - 1, defaultIndex = metadata.defaultValues.Length - 1;     // fill missing parameters from the back 
+                    paramIndex >= suppliedParamsCount && defaultIndex >= 0;                                        // to don't overwrite supplied ones.
+                    paramIndex--, defaultIndex--)
+                {
+                    parameters[paramIndex] = metadata.defaultValues[defaultIndex].Value;
+                }
+
+                if (missingParamsCount > metadata.defaultValues.Length)
+                {
+                    JsonResponse response = new JsonResponse
+                    {
+                        Error = ProcessException(Rpc,
+                            new JsonRpcException(-32602,
+                                "Invalid params",
+                                string.Format(
+                                    "Number of default parameters {0} not sufficient to fill all missing parameters {1}",
+                                    metadata.defaultValues.Length, missingParamsCount)
+                                )),
+                        Id = Rpc.Id
+                    };
+                    return PostProcess(Rpc, response, RpcContext);
+                }
+            }
+
+            if (parameters.Length != metaDataParamCount)
+            {
+                JsonResponse response = new JsonResponse()
+                {
+                    Error = ProcessException(Rpc,
+                    new JsonRpcException(-32602,
+                        "Invalid params",
+                        string.Format("Expecting {0} parameters, and received {1}",
+                                        metadata.parameters.Length,
+                                        parameters.Length)
+                        )),
+                    Id = Rpc.Id
+                };
+                return PostProcess(Rpc, response, RpcContext);
+            }
+
+            try
+            {
+                var results = handle.DynamicInvoke(parameters);
+                
+                var last = parameters.LastOrDefault();
+                var contextException = RpcGetAndRemoveRpcException();
+                JsonResponse response = null;
+                if (contextException != null)
+                {
+                    response = new JsonResponse() { Error = ProcessException(Rpc, contextException), Id = Rpc.Id };
+                }
+                else if (expectsRefException && last != null && last is JsonRpcException)
+                {
+                    response = new JsonResponse() { Error = ProcessException(Rpc, last as JsonRpcException), Id = Rpc.Id };
+                }
+                else
+                {
+                    response = new JsonResponse() { Result = results };
+                }
+                return PostProcess(Rpc, response, RpcContext);
+            }
+            catch (Exception ex)
+            {
+                JsonResponse response;
+                if (ex is TargetParameterCountException)
+                {
+                    response = new JsonResponse() { Error = ProcessException(Rpc, new JsonRpcException(-32602, "Invalid params", ex)) };
+                    return PostProcess(Rpc, response, RpcContext);
+                }
+
+                // We really dont care about the TargetInvocationException, just pass on the inner exception
+                if (ex is JsonRpcException)
+                {
+                    response = new JsonResponse() { Error = ProcessException(Rpc, ex as JsonRpcException) };
+                    return PostProcess(Rpc, response, RpcContext);
+                }
+                if (ex.InnerException != null && ex.InnerException is JsonRpcException)
+                {
+                    response = new JsonResponse() { Error = ProcessException(Rpc, ex.InnerException as JsonRpcException) };
+                    return PostProcess(Rpc, response, RpcContext);
+                }
+                else if (ex.InnerException != null)
+                {
+                    response = new JsonResponse() { Error = ProcessException(Rpc, new JsonRpcException(-32603, "Internal Error", ex.InnerException)) };
+                    return PostProcess(Rpc, response, RpcContext);
+                }
+
+                response = new JsonResponse() { Error = ProcessException(Rpc, new JsonRpcException(-32603, "Internal Error", ex)) };
+                return PostProcess(Rpc, response, RpcContext);
+            }
+            finally
+            {
+                RemoveRpcContext();
+            }
+        }
+        #endregion
+
+        [ThreadStatic]
+        static object __currentRpcContext;
+        private void AddRpcContext(object RpcContext)
+        {
+            __currentRpcContext = RpcContext;
+        }
+        private void RemoveRpcContext()
+        {
+            __currentRpcContext = null;
+        }
+
+        private JsonRpcException ProcessException(JsonRequest req, JsonRpcException ex)
+        {
+            if (externalErrorHandler != null)
+                return externalErrorHandler(req, ex);
+            return ex;
+        }
+        internal JsonRpcException ProcessParseException(string req, JsonRpcException ex)
+        {
+            if (parseErrorHandler != null)
+                return parseErrorHandler(req, ex);
+            return ex;
+        }
+        internal void SetErrorHandler(Func<JsonRequest, JsonRpcException, JsonRpcException> handler)
+        {
+            externalErrorHandler = handler;
+        }
+        internal void SetParseErrorHandler(Func<string, JsonRpcException, JsonRpcException> handler)
+        {
+            parseErrorHandler = handler;
+        }
+       
+        private object CleanUpParameter(object p, SMDAdditionalParameters metaData)
+        {
+            var bob = p as JValue;
+
+            if (bob != null)
+            {
+                if (bob.Value == null || metaData.ObjectType == bob.Value.GetType())
+                {
+                    return bob.Value;
+                }
+
+                // Avoid calling DeserializeObject on types that JValue has an explicit converter for
+                // try to optimize for the most common types
+                if (metaData.ObjectType == typeof(string)) return (string)bob;
+                if (metaData.ObjectType == typeof(int)) return (int)bob;
+                if (metaData.ObjectType == typeof(double)) return (double)bob;
+                if (metaData.ObjectType == typeof(float)) return (float)bob;
+                //if (metaData.ObjectType == typeof(long)) return (long)bob;
+                //if (metaData.ObjectType == typeof(uint)) return (uint)bob;
+                //if (metaData.ObjectType == typeof(ulong)) return (ulong)bob;
+                //if (metaData.ObjectType == typeof(byte[])) return (byte[])bob;
+                //if (metaData.ObjectType == typeof(Guid)) return (Guid)bob;
+                if (metaData.ObjectType == typeof(decimal)) return (decimal)bob;
+                //if (metaData.ObjectType == typeof(TimeSpan)) return (TimeSpan)bob;
+                //if (metaData.ObjectType == typeof(short)) return (short)bob;
+                //if (metaData.ObjectType == typeof(ushort)) return (ushort)bob;
+                //if (metaData.ObjectType == typeof(char)) return (char)bob;
+                //if (metaData.ObjectType == typeof(DateTime)) return (DateTime)bob;
+                //if (metaData.ObjectType == typeof(bool)) return (bool)bob;
+                //if (metaData.ObjectType == typeof(DateTimeOffset)) return (DateTimeOffset)bob;
+
+                if (metaData.ObjectType.IsAssignableFrom(typeof(JValue)))
+                    return bob;
+
+                try
+                {
+                    return bob.ToObject(metaData.ObjectType);
+                }
+                catch (Exception ex)
+                {
+                    // no need to throw here, they will
+                    // get an invalid cast exception right after this.
+                }
+            }
+            else
+            {
+                try
+                {
+                    if (p is string)
+                        return JsonConvert.DeserializeObject((string)p, metaData.ObjectType);
+                    return JsonConvert.DeserializeObject(p.ToString(), metaData.ObjectType);
+                }
+                catch (Exception ex)
+                {
+                    // no need to throw here, they will
+                    // get an invalid cast exception right after this.
+                }
+            }
+
+            return p;
+        }
+
+        private JsonRpcException PreProcess(JsonRequest request, object context)
+        {
+            return externalPreProcessingHandler == null ? null : externalPreProcessingHandler(request, context);
+        }
+
+        private JsonResponse PostProcess(JsonRequest request, JsonResponse response, object context)
+        {
+            if (externalPostProcessingHandler != null)
+            {
+                try
+                {
+                    JsonRpcException exception = externalPostProcessingHandler(request, response, context);
+                    if (exception != null)
+                    {
+                        response = new JsonResponse() { Error = exception };
+                    }
+                }
+                catch (Exception ex)
+                {
+                    response = new JsonResponse() { Error = ProcessException(request, new JsonRpcException(-32603, "Internal Error", ex)) };
+                }
+            }
+            return response;
+        }
+
+    }
+
+}
+

--- a/AustinHarris.JsonRpc.Standard/JsonRequest.cs
+++ b/AustinHarris.JsonRpc.Standard/JsonRequest.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+
+namespace AustinHarris.JsonRpc
+{
+    /// <summary>
+    /// Represents a JsonRpc request
+    /// </summary>
+    [JsonObject(MemberSerialization.OptIn)]
+    public class JsonRequest
+    {
+        public JsonRequest()
+        {
+        }
+
+        public JsonRequest(string method, object pars, object id)
+        {
+            Method = method;
+            Params = pars;
+            Id = id;
+        }
+
+        [JsonProperty("jsonrpc")]
+        public string JsonRpc => "2.0";
+
+        [JsonProperty("method")]
+        public string Method { get; set; }
+
+        [JsonProperty("params")]
+        public object Params { get; set; }
+
+        [JsonProperty("id")]
+        public object Id { get; set; }
+    }
+}

--- a/AustinHarris.JsonRpc.Standard/JsonResponse.cs
+++ b/AustinHarris.JsonRpc.Standard/JsonResponse.cs
@@ -1,0 +1,42 @@
+﻿using Newtonsoft.Json;
+
+namespace AustinHarris.JsonRpc
+{
+    /// <summary>
+    /// Represents a Json Rpc Response
+    /// </summary>
+    [JsonObject(MemberSerialization.OptIn)]
+    public class JsonResponse
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "jsonrpc")]
+        public string JsonRpc { get { return "2.0"; } }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "result")]
+        public object Result { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "error")]
+        public JsonRpcException Error { get; set; }
+
+        [JsonProperty(PropertyName = "id")]
+        public object Id { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a Json Rpc Response
+    /// </summary>
+    [JsonObject(MemberSerialization.OptIn)]
+    public class JsonResponse<T>
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "jsonrpc")]
+        public string JsonRpc { get { return "2.0"; } }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "result")]
+        public T Result { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "error")]
+        public JsonRpcException Error { get; set; }
+
+        [JsonProperty(PropertyName = "id")]
+        public object Id { get; set; }
+    }
+}

--- a/AustinHarris.JsonRpc.Standard/JsonResponseErrorObject.cs
+++ b/AustinHarris.JsonRpc.Standard/JsonResponseErrorObject.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace AustinHarris.JsonRpc
+{
+    /// <summary>
+    ///  5.1 Error object
+    ///
+    ///  When a rpc call encounters an error, the Response Object MUST contain the error member with a value that is a Object with the following members:
+    ///  codeA Number that indicates the error type that occurred.
+    ///  This MUST be an integer.messageA String providing a short description of the error.
+    ///  The message SHOULD be limited to a concise single sentence.dataA Primitive or Structured value that contains additional information about the error.
+    ///  This may be omitted.
+    ///  The value of this member is defined by the Server (e.g. detailed error information, nested errors etc.).
+    ///  The error codes from and including -32768 to -32000 are reserved for pre-defined errors. Any code within this range, but not defined explicitly below is reserved for future use. The error codes are nearly the same as those suggested for XML-RPC at the following url: http://xmlrpc-epi.sourceforge.net/specs/rfc.fault_codes.php
+    ///
+    ///  code        message             meaning
+    ///
+    ///  -32700      Parse error         Invalid JSON was received by the server.  An error occurred on the server while parsing the JSON text.
+    ///  -32600      Invalid Request     The JSON sent is not a valid Request object.
+    ///  -32601      Method not found    The method does not exist / is not available.
+    ///  -32602      Invalid params      Invalid method parameter(s).
+    ///  -32603      Internal error      Internal JSON-RPC error.
+    ///  -32000 to -32099 Server error   Reserved for implementation-defined server-errors.
+    ///
+    ///  The remainder of the space is available for application defined errors.
+    /// </summary>
+    [Serializable]
+    [JsonObject(MemberSerialization.OptIn)]    
+    public class JsonRpcException : System.ApplicationException
+    {
+        [JsonProperty]
+        public int code { get; set; }
+
+        [JsonProperty]
+        public string message { get; set; }
+
+        [JsonProperty]
+        public object data { get; set; }
+
+        public JsonRpcException(int code, string message, object data)
+        {
+            this.code = code;
+            this.message = message;
+            this.data = data;
+        }
+    }
+}

--- a/AustinHarris.JsonRpc.Standard/JsonRpcContext.cs
+++ b/AustinHarris.JsonRpc.Standard/JsonRpcContext.cs
@@ -1,0 +1,39 @@
+﻿namespace AustinHarris.JsonRpc
+{
+    /// <summary>
+    /// Provides access to a context specific to each JsonRpc method invocation.
+    /// This is a convienence class that wraps calls to Context specific methods on AustinHarris.JsonRpc.Handler
+    /// </summary>
+    public class JsonRpcContext
+    {
+        private JsonRpcContext(object value)
+        {
+            Value = value;
+        }
+
+        /// <summary>
+        /// The data associated with this context.
+        /// </summary>
+        public object Value { get; private set; }
+
+        /// <summary>
+        /// Allows you to set the exception used in in the JsonRpc response.
+        /// Warning: Must be called from within the execution context of the jsonRpc method to function.
+        /// </summary>
+        /// <param name="exception"></param>
+        public static void SetException(JsonRpcException exception)
+        {
+            Handler.RpcSetException(exception);
+        }
+
+
+        /// <summary>
+        /// Must be called from within the execution context of the jsonRpc Method to return the context
+        /// </summary>
+        /// <returns></returns>
+        public static JsonRpcContext Current()
+        {
+            return new JsonRpcContext(Handler.RpcContext());
+        }
+    }
+}

--- a/AustinHarris.JsonRpc.Standard/JsonRpcProcessor.cs
+++ b/AustinHarris.JsonRpc.Standard/JsonRpcProcessor.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.IO;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace AustinHarris.JsonRpc
+{
+    public static class JsonRpcProcessor
+    {
+        public static void Process(JsonRpcStateAsync async, object context = null)
+        {
+            Process(Handler.DefaultSessionId(), async, context);
+        }
+
+        public static void Process(string sessionId, JsonRpcStateAsync async, object context = null)
+        {
+            Process(sessionId, async.JsonRpc, context)
+                .ContinueWith(t =>
+            {
+                async.Result = t.Result;
+                async.SetCompleted();
+            });
+        }
+        public static Task<string> Process(string jsonRpc, object context = null)
+        {
+            return Process(Handler.DefaultSessionId(), jsonRpc, context);
+        }
+        public static Task<string> Process(string sessionId, string jsonRpc, object context = null)
+        { 
+            return Task<string>.Factory.StartNew((_) =>
+            {
+                var tuple = (Tuple<string, string, object>)_;
+                return ProcessInternal(tuple.Item1, tuple.Item2, tuple.Item3);
+            }, new Tuple<string, string, object>(sessionId, jsonRpc, context));
+        }
+
+        private static string ProcessInternal(string sessionId, string jsonRpc, object jsonRpcContext)
+        {
+            var handler = Handler.GetSessionHandler(sessionId);
+
+
+            JsonRequest[] batch = null;
+            try
+            {
+                if (isSingleRpc(jsonRpc))
+                {
+                    var foo = JsonConvert.DeserializeObject<JsonRequest>(jsonRpc);
+                    batch = new[] { foo };
+                }
+                else
+                {
+                    batch = JsonConvert.DeserializeObject<JsonRequest[]>(jsonRpc);
+                }
+            }
+            catch (Exception ex)
+            {
+                return Newtonsoft.Json.JsonConvert.SerializeObject(new JsonResponse
+                {
+                    Error = handler.ProcessParseException(jsonRpc, new JsonRpcException(-32700, "Parse error", ex))
+                });
+            }
+
+            if (batch.Length == 0)
+            {
+                return Newtonsoft.Json.JsonConvert.SerializeObject(new JsonResponse
+                {
+                    Error = handler.ProcessParseException(jsonRpc,
+                        new JsonRpcException(3200, "Invalid Request", "Batch of calls was empty."))
+                });
+            }
+
+            var singleBatch = batch.Length == 1;
+            StringBuilder sbResult = null;
+            for (var i = 0; i < batch.Length; i++)
+            {
+                var jsonRequest = batch[i];
+                var jsonResponse = new JsonResponse();
+
+                if (jsonRequest == null)
+                {
+                    jsonResponse.Error = handler.ProcessParseException(jsonRpc,
+                        new JsonRpcException(-32700, "Parse error",
+                            "Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text."));
+                }
+                else if (jsonRequest.Method == null)
+                {
+                    jsonResponse.Error = handler.ProcessParseException(jsonRpc,
+                        new JsonRpcException(-32600, "Invalid Request", "Missing property 'method'"));
+                }
+                else
+                {
+                    jsonResponse.Id = jsonRequest.Id;
+
+                    var data = handler.Handle(jsonRequest, jsonRpcContext);
+
+                    if (data == null) continue;
+
+                    jsonResponse.Error = data.Error;
+                    jsonResponse.Result = data.Result;
+
+                }
+                if (jsonResponse.Result == null && jsonResponse.Error == null)
+                {
+                    // Per json rpc 2.0 spec
+                    // result : This member is REQUIRED on success.
+                    // This member MUST NOT exist if there was an error invoking the method.    
+                    // Either the result member or error member MUST be included, but both members MUST NOT be included.
+                    jsonResponse.Result = new Newtonsoft.Json.Linq.JValue((Object)null);
+                }
+                // special case optimization for single Item batch
+                if (singleBatch && (jsonResponse.Id != null || jsonResponse.Error != null))
+                {
+                    StringWriter sw = new StringWriter();
+                    JsonTextWriter writer = new JsonTextWriter(sw);
+                    writer.WriteStartObject();
+                    writer.WritePropertyName("jsonrpc"); writer.WriteValue("2.0");
+
+                    if (jsonResponse.Error != null)
+                    {
+                        writer.WritePropertyName("error"); writer.WriteRawValue(JsonConvert.SerializeObject(jsonResponse.Error));
+                    }
+                    else
+                    {
+                        writer.WritePropertyName("result"); writer.WriteRawValue(JsonConvert.SerializeObject(jsonResponse.Result));
+                    }
+                    writer.WritePropertyName("id"); writer.WriteValue(jsonResponse.Id);
+                    writer.WriteEndObject();
+                    return sw.ToString();
+
+                    //return JsonConvert.SerializeObject(jsonResponse);
+                }
+                else if (jsonResponse.Id == null && jsonResponse.Error == null)
+                {
+                    // do nothing
+                    sbResult = new StringBuilder(0);
+                }
+                else
+                {
+                    // write out the response
+                    if (i == 0)
+                    {
+                        sbResult = new StringBuilder("[");
+                    }
+
+                    sbResult.Append(JsonConvert.SerializeObject(jsonResponse));
+                    if (i < batch.Length - 1)
+                    {
+                        sbResult.Append(',');
+                    }
+                    else if (i == batch.Length - 1)
+                    {
+                        sbResult.Append(']');
+                    }
+                }
+            }
+            return sbResult.ToString();
+        }
+
+        private static bool isSingleRpc(string json)
+        {
+            for (int i = 0; i < json.Length; i++)
+            {
+                if (json[i] == '{') return true;
+                else if (json[i] == '[') return false;
+            }
+            return true;
+        }
+    }
+}

--- a/AustinHarris.JsonRpc.Standard/JsonRpcService.cs
+++ b/AustinHarris.JsonRpc.Standard/JsonRpcService.cs
@@ -1,0 +1,22 @@
+﻿namespace AustinHarris.JsonRpc
+{
+    /// <summary>
+    ///     For routing use SessionId
+    /// </summary>
+    public abstract class JsonRpcService
+    {
+        protected JsonRpcService()
+        {
+            ServiceBinder.BindService(Handler.DefaultSessionId(), this);
+        }
+
+        /// <summary>
+        ///     Routing by SessionId
+        /// </summary>
+        /// <param name="sessionID"></param>
+        protected JsonRpcService(string sessionID)
+        {
+            ServiceBinder.BindService(sessionID, this);
+        }
+    }
+}

--- a/AustinHarris.JsonRpc.Standard/JsonRpcStateAsync.cs
+++ b/AustinHarris.JsonRpc.Standard/JsonRpcStateAsync.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading;
+
+namespace AustinHarris.JsonRpc
+{
+    public class JsonRpcStateAsync : IAsyncResult
+    {
+        public JsonRpcStateAsync(AsyncCallback cb, Object extraData)
+        {
+            this.cb = cb;
+            asyncState = extraData;
+            isCompleted = false;
+        }
+
+        public string JsonRpc { get; set; }
+        public string Result { get; set; }
+
+        private AsyncCallback cb = null;
+        private Object asyncState;
+        public object AsyncState
+        {
+            get
+            {
+                return asyncState;
+            }
+        }
+
+        public bool CompletedSynchronously
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        // If this object was not being used solely with ASP.Net this
+        // method would need an implementation. ASP.Net never uses the
+        // event, so it is not implemented here.
+        public WaitHandle AsyncWaitHandle
+        {
+            get
+            {
+                // not supported
+                return null;
+            }
+        }
+
+        private Boolean isCompleted;
+        public bool IsCompleted
+        {
+            get
+            {
+                return isCompleted;
+            }
+        }
+
+        internal void SetCompleted()
+        {
+            isCompleted = true;
+            if (cb != null)
+            {
+                cb(this);
+            }
+        }
+    }
+}

--- a/AustinHarris.JsonRpc.Standard/SMDService.cs
+++ b/AustinHarris.JsonRpc.Standard/SMDService.cs
@@ -1,0 +1,273 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using System.Reflection;
+using Newtonsoft.Json.Linq;
+
+namespace AustinHarris.JsonRpc
+{
+    public class SMD
+    {
+        public string transport { get; set; }
+        public string envelope { get; set; }
+        public string target { get; set; }
+        public bool additonalParameters { get; set; }
+        public SMDAdditionalParameters[] parameters { get; set; }
+        [JsonIgnore]
+        public static List<string> TypeHashes { get; set; }
+        [JsonProperty("types")]
+        public static Dictionary<int,JObject> Types { get; set; }
+        [JsonProperty("services")]
+        public Dictionary<string, SMDService> Services { get; set; }
+
+        public SMD ()
+	    {
+            transport = "POST";
+            envelope = "URL";
+            target = "/json.rpc";
+            additonalParameters = false;
+            parameters = new SMDAdditionalParameters[0];
+            Services = new Dictionary<string,SMDService>();
+            Types = new Dictionary<int, JObject>();
+            TypeHashes = new List<string>();
+	    }
+
+        internal void AddService(string method, Dictionary<string,Type> parameters, Dictionary<string, object> defaultValues, Delegate dele)
+        {
+            var newService = new SMDService(transport,"JSON-RPC-2.0",parameters, defaultValues, dele);
+            Services.Add(method,newService);
+        }
+
+        public static int AddType(JObject jo)
+        {
+            var hash = string.Format("t_{0}", jo.ToString().GetHashCode());
+            
+            lock (TypeHashes)
+            {
+                if (TypeHashes.Contains(hash)) return TypeHashes.IndexOf(hash);
+                
+                TypeHashes.Add(hash);
+                var idx = TypeHashes.IndexOf(hash);                    
+                Types.Add(idx, jo);
+            }
+
+            return TypeHashes.IndexOf(hash); 
+        }
+
+        public static bool ContainsType(JObject jo)
+        {
+            return TypeHashes.Contains(string.Format("t_{0}", jo.ToString().GetHashCode()));
+        }
+    }
+
+    public class SMDService
+    {
+        public Delegate dele;
+        /// <summary>
+        /// Defines a service method http://dojotoolkit.org/reference-guide/1.8/dojox/rpc/smd.html
+        /// </summary>
+        /// <param name="transport">POST, GET, REST, JSONP, TCP/IP</param>
+        /// <param name="envelope">URL, PATH, JSON, JSON-RPC-1.0, JSON-RPC-1.1, JSON-RPC-2.0</param>
+        /// <param name="parameters"></param>
+        /// <param name="defaultValues"></param>
+        public SMDService(string transport, string envelope, Dictionary<string, Type> parameters, Dictionary<string, object> defaultValues, Delegate dele)
+        {
+            // TODO: Complete member initialization
+            this.dele = dele;
+            this.transport = transport;
+            this.envelope = envelope;
+            this.parameters = new SMDAdditionalParameters[parameters.Count-1]; // last param is return type similar to Func<,>
+            int ctr=0;
+            foreach (var item in parameters)
+	        {
+                if (ctr < parameters.Count -1)// never the last one. last one is the return type.
+                {
+                    this.parameters[ctr++] = new SMDAdditionalParameters(item.Key, item.Value);
+                }
+	        }
+
+            // create the default values storage for optional parameters.
+            this.defaultValues = new ParameterDefaultValue[defaultValues.Count];
+            int counter = 0;
+            foreach (var item in defaultValues)
+            {
+                this.defaultValues[counter++] = new ParameterDefaultValue(item.Key, item.Value);
+            }
+
+            // this is getting the return type from the end of the param list
+            this.returns = new SMDResult(parameters.Values.LastOrDefault());
+        }
+        public string transport { get; private set; }
+        public string envelope { get; private set; }
+        public SMDResult returns { get; private set; }
+
+        /// <summary>
+        /// This indicates what parameters may be supplied for the service calls. 
+        /// A parameters value MUST be an Array. Each value in the parameters Array should describe a parameter 
+        /// and follow the JSON Schema property definition. Each of parameters that are defined at the root level
+        /// are inherited by each of service definition's parameters. The parameter definition follows the 
+        /// JSON Schema property definition with the additional properties:
+        /// </summary>
+        public SMDAdditionalParameters[] parameters { get; private set; }
+
+        /// <summary>
+        /// Stores default values for optional parameters.
+        /// </summary>
+        public ParameterDefaultValue[] defaultValues { get; private set; }
+    }
+
+    public class SMDResult
+    {
+        [JsonProperty("__type")]
+        public int Type { get; private set; }
+
+        public SMDResult(System.Type type)
+        {
+            Type = SMDAdditionalParameters.GetTypeRecursive(type);
+        }
+    }
+
+    /// <summary>
+    /// Holds default value for parameters.
+    /// </summary>
+    public class ParameterDefaultValue
+    {
+        /// <summary>
+        /// Name of the parameter.
+        /// </summary>
+        public string Name { get; private set; }
+        /// <summary>
+        /// Default value for the parameter.
+        /// </summary>
+        public object Value { get; private set; }
+
+        public ParameterDefaultValue(string name, object value)
+        {
+            this.Name = name;
+            this.Value = value;
+        }
+    }
+
+    public class SMDAdditionalParameters
+    {
+        public  SMDAdditionalParameters(string parametername, System.Type type)
+        {
+            Name = parametername;
+            Type = GetTypeRecursive(ObjectType = type);
+          
+        }
+
+        [JsonIgnore()]
+        public Type ObjectType { get; set; }
+        [JsonProperty("__name")]
+        public string Name { get; set; }
+        [JsonProperty("__type")]
+        public int Type { get; set; }
+
+        internal static int GetTypeRecursive(Type t)
+        {
+            JObject jo = new JObject();
+            jo.Add("__name", t.Name.ToLower());
+
+            if (isSimpleType(t) || SMD.ContainsType(jo))
+            {                
+                return SMD.AddType(jo);
+            }
+
+            var retVal = SMD.AddType(jo);
+
+            var genArgs = t.GetGenericArguments();
+            PropertyInfo[] properties = t.GetProperties();
+            FieldInfo[] fields = t.GetFields();
+
+            if (genArgs.Length > 0)
+            {
+                var ja = new JArray();
+                foreach (var item in genArgs)
+                {
+                    if (item != t)
+                    {
+                        var jt = GetTypeRecursive(item);
+                        ja.Add(jt);
+                    }
+                    else
+                    {
+                        // make a special case where -1 indicates this type
+                        ja.Add(-1);
+                    }
+                }
+                jo.Add("__genericArguments", ja);
+            }
+
+            foreach (var item in properties)
+            {
+                if (item.GetAccessors().Where(x => x.IsPublic).Count() > 0)
+                {
+                    if (item.PropertyType != t)
+                    {
+                        var jt = GetTypeRecursive(item.PropertyType);
+                        jo.Add(item.Name, jt);
+                    }
+                    else
+                    {
+                        // make a special case where -1 indicates this type
+                        jo.Add(item.Name, -1);
+                    }
+                }
+            }
+
+            foreach (var item in fields)
+            {
+                if (item.IsPublic)
+                {
+                    if (item.FieldType != t)
+                    {
+                        var jt = GetTypeRecursive(item.FieldType);
+                        jo.Add(item.Name, jt);
+                    }
+                    else
+                    {
+                        // make a special case where -1 indicates this type
+                        jo.Add(item.Name, -1);
+                    }
+                }
+            }
+
+            return retVal;
+        }
+
+        internal static bool isSimpleType(Type t)
+        {
+            var name = t.FullName.ToLower();
+
+            if (name.Contains("newtonsoft")
+                || name == "system.sbyte"
+                || name == "system.byte"
+                || name == "system.int16"
+                || name == "system.uint16"
+                || name == "system.int32"
+                || name == "system.uint32"
+                || name == "system.int64"
+                || name == "system.uint64"
+                || name == "system.char"
+                || name == "system.single"
+                || name == "system.double"
+                || name == "system.boolean"
+                || name == "system.decimal"
+                || name == "system.float"
+                || name == "system.numeric"
+                || name == "system.money"
+                || name == "system.string"
+                || name == "system.object"
+                || name == "system.type"
+               // || name == "system.datetime"
+                || name == "system.reflection.membertypes")
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/AustinHarris.JsonRpc.Standard/ServiceBinder.cs
+++ b/AustinHarris.JsonRpc.Standard/ServiceBinder.cs
@@ -1,0 +1,70 @@
+﻿namespace AustinHarris.JsonRpc
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    public static class ServiceBinder
+    {
+        public static void BindService<T>() where T : new()
+        {
+            BindService<T>(Handler.DefaultSessionId());
+        }
+        public static void BindService<T>(string sessionID) where T : new()
+        {
+            BindService(sessionID, new T());
+        }
+
+        public static void BindService(string sessionID, Object instance)
+        {
+            var item = instance.GetType(); // var item = typeof(T);
+
+            var methods = item.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(m => m.GetCustomAttributes(typeof(JsonRpcMethodAttribute), false).Length > 0);
+            foreach (var meth in methods)
+            {
+                Dictionary<string, Type> paras = new Dictionary<string, Type>();
+                Dictionary<string, object> defaultValues = new Dictionary<string, object>(); // dictionary that holds default values for optional params.
+
+                var paramzs = meth.GetParameters();
+
+                List<Type> parameterTypeArray = new List<Type>();
+                for (int i = 0; i < paramzs.Length; i++)
+                {
+                    string paramName; 
+                    var paramAttrs = paramzs[i].GetCustomAttributes(typeof(JsonRpcParamAttribute), false); 
+                    if (paramAttrs.Length > 0) 
+                    { 
+                        paramName = ((JsonRpcParamAttribute)paramAttrs[0]).JsonParamName;
+                        if (string.IsNullOrEmpty(paramName))
+                        {
+                            paramName = paramzs[i].Name; 
+                        }
+                    } 
+                    else 
+                    { 
+                        paramName = paramzs[i].Name; 
+                    } 
+                    // reflection attribute information for optional parameters
+                    //http://stackoverflow.com/questions/2421994/invoking-methods-with-optional-parameters-through-reflection
+                    paras.Add(paramName, paramzs[i].ParameterType);
+
+                    if (paramzs[i].IsOptional) // if the parameter is an optional, add the default value to our default values dictionary.
+                        defaultValues.Add(paramName, paramzs[i].DefaultValue);
+                }
+
+                var resType = meth.ReturnType;
+                paras.Add("returns", resType); // add the return type to the generic parameters list.
+
+                var atdata = meth.GetCustomAttributes(typeof(JsonRpcMethodAttribute), false);
+                foreach (JsonRpcMethodAttribute handlerAttribute in atdata)
+                {
+                    var methodName = handlerAttribute.JsonMethodName == string.Empty ? meth.Name : handlerAttribute.JsonMethodName;
+                    var newDel = Delegate.CreateDelegate(System.Linq.Expressions.Expression.GetDelegateType(paras.Values.ToArray()), instance /*Need to add support for other methods outside of this instance*/, meth);
+                    var handlerSession = Handler.GetSessionHandler(sessionID);
+                    handlerSession.MetaData.AddService(methodName, paras, defaultValues, newDel);
+                }
+            }
+        }
+    }
+}

--- a/AustinHarris.JsonRpc.sln
+++ b/AustinHarris.JsonRpc.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2003
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BBFBBA8A-2F75-422C-ACCD-D05A6EF7244C}"
 	ProjectSection(SolutionItems) = preProject
@@ -18,6 +18,16 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AustinHarris.JsonRpcTestN", "AustinHarris.JsonRpcTestN\AustinHarris.JsonRpcTestN.csproj", "{8569B076-5A8B-4D6A-B75D-EF75A390AA5F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestServer_Console", "TestServer_Console\TestServer_Console.csproj", "{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AustinHarris.JsonRpc.Standard", "AustinHarris.JsonRpc.Standard\AustinHarris.JsonRpc.Standard.csproj", "{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestServer_Console.Core", "TestServer_Console.Core\TestServer_Console.Core.csproj", "{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Net Framework", ".Net Framework", "{46C82A42-42F6-41AF-9421-533B5CE01CAB}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Net Core", ".Net Core", "{9FC11C57-5936-4804-A323-87D5572150EE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Net Standard", ".Net Standard", "{CB659139-9876-4850-BBB7-BC48F0B5BA22}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -89,9 +99,52 @@ Global
 		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|x86.ActiveCfg = Release|x86
 		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B}.Release|x86.Build.0 = Release|x86
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Debug|ARM.Build.0 = Debug|Any CPU
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Debug|x86.Build.0 = Debug|Any CPU
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Release|ARM.ActiveCfg = Release|Any CPU
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Release|ARM.Build.0 = Release|Any CPU
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Release|x86.ActiveCfg = Release|Any CPU
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0}.Release|x86.Build.0 = Release|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Debug|ARM.Build.0 = Debug|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Debug|x86.Build.0 = Debug|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Release|ARM.ActiveCfg = Release|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Release|ARM.Build.0 = Release|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Release|x86.ActiveCfg = Release|Any CPU
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{24FC1A2A-0BC3-43A7-9BFE-B628C2C4A307} = {46C82A42-42F6-41AF-9421-533B5CE01CAB}
+		{FFFDEBBC-93F5-4A22-9EC5-D86A4A792DBB} = {46C82A42-42F6-41AF-9421-533B5CE01CAB}
+		{8569B076-5A8B-4D6A-B75D-EF75A390AA5F} = {46C82A42-42F6-41AF-9421-533B5CE01CAB}
+		{31AE59FC-B6F6-4AC7-A7B9-1E07630AE42B} = {46C82A42-42F6-41AF-9421-533B5CE01CAB}
+		{01960B79-0B97-4B74-8D1F-99AFA8A0FDF0} = {CB659139-9876-4850-BBB7-BC48F0B5BA22}
+		{FDFB1B74-FBCA-4317-AFC8-7B8FC5489088} = {9FC11C57-5936-4804-A323-87D5572150EE}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {895CB7D3-766C-490E-9686-57339AE17D6B}
 	EndGlobalSection
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = AustinHarris.JsonRpc.vsmdi

--- a/TestServer_Console.Core/Program.cs
+++ b/TestServer_Console.Core/Program.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using AustinHarris.JsonRpc;
+using System.Threading;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace TestServer_Console
+{
+    class Program
+    {
+        static object[] services = new object[] {
+           new CalculatorService()
+        };
+
+        static void Main(string[] args)
+        {
+            PrintOptions();
+            for (string line = Console.ReadLine(); line != "q"; line = Console.ReadLine())
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                    Benchmark();
+                else if (line.StartsWith("c", StringComparison.CurrentCultureIgnoreCase))
+                    ConsoleInput();
+                PrintOptions();
+            }
+        }
+
+        private static void PrintOptions()
+        {
+            Console.WriteLine("Hit Enter to run benchmark");
+            Console.WriteLine("'c' to start reading console input");
+            Console.WriteLine("'q' to quit");
+        }
+
+        private static void ConsoleInput()
+        {
+            for (string line = Console.ReadLine(); !string.IsNullOrEmpty(line); line = Console.ReadLine())
+            {
+                JsonRpcProcessor.Process(line).ContinueWith(response => Console.WriteLine( response.Result ));
+            }
+        }
+
+        private static volatile int ctr;
+        private static void Benchmark()
+        {
+            Console.WriteLine("Starting benchmark");
+           
+            var cnt = 50;
+            var iterations = 7;
+            for (int iteration = 1; iteration <= iterations; iteration++)
+            {
+                cnt *= iteration;
+                ctr = 0;
+                Task<string>[] tasks = new Task<string>[cnt];
+                var sw = Stopwatch.StartNew();
+
+                var sessionid = Handler.DefaultSessionId();
+                for (int i = 0; i < cnt; i+=5)
+                {
+                    tasks[i] = JsonRpcProcessor.Process(sessionid, "{'method':'add','params':[1,2],'id':1}");
+                    tasks[i+1] = JsonRpcProcessor.Process(sessionid, "{'method':'addInt','params':[1,7],'id':2}");
+                    tasks[i+2] = JsonRpcProcessor.Process(sessionid, "{'method':'NullableFloatToNullableFloat','params':[1.23],'id':3}");
+                    tasks[i+3] = JsonRpcProcessor.Process(sessionid, "{'method':'Test2','params':[3.456],'id':4}");
+                    tasks[i+4] = JsonRpcProcessor.Process(sessionid, "{'method':'StringMe','params':['Foo'],'id':5}");
+                }
+                Task.WaitAll(tasks);
+                sw.Stop();
+                Console.WriteLine("processed {0} rpc in {1}ms for {2} rpc/sec", cnt, sw.ElapsedMilliseconds, (double)cnt * 1000d / sw.ElapsedMilliseconds);
+            }
+
+
+            Console.WriteLine("Finished benchmark...");
+        }
+
+    }
+
+    
+}

--- a/TestServer_Console.Core/TestServer_Console.Core.csproj
+++ b/TestServer_Console.Core/TestServer_Console.Core.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AustinHarris.JsonRpc.Standard\AustinHarris.JsonRpc.Standard.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TestServer_Console.Core/service.cs
+++ b/TestServer_Console.Core/service.cs
@@ -1,0 +1,131 @@
+﻿using AustinHarris.JsonRpc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TestServer_Console
+{
+    public class CalculatorService : JsonRpcService
+    {
+        [JsonRpcMethod]
+        private double add(double l, double r)
+        {
+            return l + r;
+        }
+
+        [JsonRpcMethod]
+        private int addInt(int l, int r)
+        {
+            return l + r;
+        }
+
+        [JsonRpcMethod]
+        public float? NullableFloatToNullableFloat(float? a)
+        {
+            return a;
+        }
+
+        [JsonRpcMethod]
+        public decimal? Test2(decimal x)
+        {
+            return x;
+        }
+
+        [JsonRpcMethod]
+        public string StringMe(string x)
+        {
+            return x;
+        }
+
+        [JsonRpcMethod]
+        private double add_1(double l, double r)
+        {
+            return l + r;
+        }
+
+        [JsonRpcMethod]
+        private int addInt_1(int l, int r)
+        {
+            return l + r;
+        }
+
+        [JsonRpcMethod]
+        public float? NullableFloatToNullableFloat_1(float? a)
+        {
+            return a;
+        }
+
+        [JsonRpcMethod]
+        public decimal? Test2_1(decimal x)
+        {
+            return x;
+        }
+
+        [JsonRpcMethod]
+        public string StringMe_1(string x)
+        {
+            return x;
+        }
+
+        [JsonRpcMethod]
+        private double add_2(double l, double r)
+        {
+            return l + r;
+        }
+
+        [JsonRpcMethod]
+        private int addInt_2(int l, int r)
+        {
+            return l + r;
+        }
+
+        [JsonRpcMethod]
+        public float? NullableFloatToNullableFloat_2(float? a)
+        {
+            return a;
+        }
+
+        [JsonRpcMethod]
+        public decimal? Test2_2(decimal x)
+        {
+            return x;
+        }
+
+        [JsonRpcMethod]
+        public string StringMe_2(string x)
+        {
+            return x;
+        }
+
+        [JsonRpcMethod]
+        private double add_3(double l, double r)
+        {
+            return l + r;
+        }
+
+        [JsonRpcMethod]
+        private int addInt_3(int l, int r)
+        {
+            return l + r;
+        }
+
+        [JsonRpcMethod]
+        public float? NullableFloatToNullableFloat_3(float? a)
+        {
+            return a;
+        }
+
+        [JsonRpcMethod]
+        public decimal? Test2_3(decimal x)
+        {
+            return x;
+        }
+
+        [JsonRpcMethod]
+        public string StringMe_3(string x)
+        {
+            return x;
+        }
+    }
+}


### PR DESCRIPTION
This is for issue #89 

## Todo

Feel free to provide a pull request into this branch for any of the below.

- [x] Create AustinHarris.JsonRpc.Standard - Targets .Net Standard 2.0
- [x] Create TestServer_Console.Core - Targets .Net Core 2.0 
- [ ] Decouple main library from Json.Net and allow serialization to be injected.
- [ ] Provide examples of getting setup with Json.net
- [ ] Provide examples of getting setup with some alternative (Suggestions?)
- [ ] Figure out the Nuget situation
- [ ] Determine if we can target a lower version of .Net Standard or if it isn't worth the effort
