### PR TITLE
supports async/await on JsonRpcService methods.

### DIFF
--- a/Json-Rpc/AustinHarris.JsonRpc.csproj
+++ b/Json-Rpc/AustinHarris.JsonRpc.csproj
@@ -17,7 +17,7 @@
     <SccProvider>SAK</SccProvider>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\CoiniumServ\build\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -47,6 +47,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -54,6 +55,7 @@
     <WarningLevel>4</WarningLevel>
     <Optimize>true</Optimize>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Attributes.cs" />

--- a/Json-Rpc/Handler.cs
+++ b/Json-Rpc/Handler.cs
@@ -339,8 +339,14 @@
                     var task = (Task)results;
                     await task;
                     PropertyInfo pInfo = task.GetType().GetRuntimeProperty("Result");
-                    if (pInfo != null)
+                    if (pInfo != null && !pInfo.PropertyType.Name.Equals("VoidTaskResult"))
+                    {
                         results = pInfo.GetValue(task);
+                    }
+                    else
+                    {
+                        results = null;
+                    }
                 }
 
                 var last = parameters.LastOrDefault();

--- a/Json-Rpc/Handler.cs
+++ b/Json-Rpc/Handler.cs
@@ -194,7 +194,7 @@
         /// <param name="Rpc">JsonRpc Request to be processed</param>
         /// <param name="RpcContext">Optional context that will be available from within the jsonRpcMethod.</param>
         /// <returns></returns>
-        public JsonResponse Handle(JsonRequest Rpc, Object RpcContext = null)
+        public async Task<JsonResponse> Handle(JsonRequest Rpc, Object RpcContext = null)
         {
             AddRpcContext(RpcContext);
 
@@ -333,8 +333,16 @@
 
             try
             {
-                var results = handle.DynamicInvoke(parameters);
-                
+                object results = handle.DynamicInvoke(parameters);
+                if (results is Task)
+                {
+                    var task = (Task)results;
+                    await task;
+                    PropertyInfo pInfo = task.GetType().GetRuntimeProperty("Result");
+                    if (pInfo != null)
+                        results = pInfo.GetValue(task);
+                }
+
                 var last = parameters.LastOrDefault();
                 var contextException = RpcGetAndRemoveRpcException();
                 JsonResponse response = null;

--- a/Json-Rpc/JsonRpcProcessor.cs
+++ b/Json-Rpc/JsonRpcProcessor.cs
@@ -84,11 +84,6 @@ namespace AustinHarris.JsonRpc
                         new JsonRpcException(-32700, "Parse error",
                             "Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text."));
                 }
-                else if (jsonRequest.Id == null)
-                {
-                    jsonResponse.Error = handler.ProcessParseException(jsonRpc,
-                        new JsonRpcException(-32600, "Invalid Request", "Missing property 'id'"));
-                }
                 else if (jsonRequest.Method == null)
                 {
                     jsonResponse.Error = handler.ProcessParseException(jsonRpc,

--- a/Json-Rpc/JsonRpcProcessor.cs
+++ b/Json-Rpc/JsonRpcProcessor.cs
@@ -84,6 +84,11 @@ namespace AustinHarris.JsonRpc
                         new JsonRpcException(-32700, "Parse error",
                             "Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text."));
                 }
+                else if (jsonRequest.Id == null)
+                {
+                    jsonResponse.Error = handler.ProcessParseException(jsonRpc,
+                        new JsonRpcException(-32600, "Invalid Request", "Missing property 'id'"));
+                }
                 else if (jsonRequest.Method == null)
                 {
                     jsonResponse.Error = handler.ProcessParseException(jsonRpc,

--- a/Json-Rpc/JsonRpcProcessor.cs
+++ b/Json-Rpc/JsonRpcProcessor.cs
@@ -27,20 +27,16 @@ namespace AustinHarris.JsonRpc
                 async.SetCompleted();
             });
         }
-        public static Task<string> Process(string jsonRpc, object context = null)
+        public static async Task<string> Process(string jsonRpc, object context = null)
         {
-            return Process(Handler.DefaultSessionId(), jsonRpc, context);
+            return await Process(Handler.DefaultSessionId(), jsonRpc, context);
         }
-        public static Task<string> Process(string sessionId, string jsonRpc, object context = null)
-        { 
-            return Task<string>.Factory.StartNew((_) =>
-            {
-                var tuple = (Tuple<string, string, object>)_;
-                return ProcessInternal(tuple.Item1, tuple.Item2, tuple.Item3);
-            }, new Tuple<string, string, object>(sessionId, jsonRpc, context));
+        public static async Task<string> Process(string sessionId, string jsonRpc, object context = null)
+        {
+            return await ProcessInternal(sessionId, jsonRpc, context);
         }
 
-        private static string ProcessInternal(string sessionId, string jsonRpc, object jsonRpcContext)
+        private static async Task<string> ProcessInternal(string sessionId, string jsonRpc, object jsonRpcContext)
         {
             var handler = Handler.GetSessionHandler(sessionId);
 
@@ -97,7 +93,7 @@ namespace AustinHarris.JsonRpc
                 {
                     jsonResponse.Id = jsonRequest.Id;
 
-                    var data = handler.Handle(jsonRequest, jsonRpcContext);
+                    var data = await handler.Handle(jsonRequest, jsonRpcContext);
 
                     if (data == null) continue;
 

--- a/Json-Rpc/packages.config
+++ b/Json-Rpc/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" requireReinstallation="true" />
 </packages>


### PR DESCRIPTION
Current JSON-RPC.NET doesn't support asynchronous call of JsonRpcService methods.
I modified that part, but changed .net framework version to 4.5 because 4.0 doesn't supports async/await keywords.