### PR TITLE
Fixes #97

### DIFF
--- a/AustinHarris.JsonRpc.AspNet/JsonRpcHandlerBase.cs
+++ b/AustinHarris.JsonRpc.AspNet/JsonRpcHandlerBase.cs
@@ -105,6 +105,7 @@ namespace AustinHarris.JsonRpc.AspNet
         /// <param name="encoding">The Encoding to be used to encode as the result.</param>
         static void CompressResponseIfPossible(HttpRequest request, HttpResponse response, String result, Encoding encoding)
         {
+            response.ContentType = "application/json-rpc";
             string acceptEncoding = request.Headers["Accept-Encoding"];
             if (acceptEncoding != null && acceptEncoding.Contains("gzip"))
             {

--- a/Json-Rpc/JsonRequest.cs
+++ b/Json-Rpc/JsonRequest.cs
@@ -20,7 +20,10 @@ namespace AustinHarris.JsonRpc
         }
 
         [JsonProperty("jsonrpc")]
-        public string JsonRpc => "2.0";
+        public string JsonRpc
+        {
+            get { return "2.0"; }
+        }
 
         [JsonProperty("method")]
         public string Method { get; set; }


### PR DESCRIPTION
According to the specification for JSON-RPC over HTTP the request and response Content-Type should be one of the following:

"application/json-rpc" - preferred
"application/json"
"application/jsonrequest"