### PR TITLE
Fix for issue #103: IndexOutOfRangeException on excess of positional parameters

### DIFF
--- a/AustinHarris.JsonRpcTestN/Test.cs
+++ b/AustinHarris.JsonRpcTestN/Test.cs
@@ -1844,6 +1844,16 @@ namespace AustinHarris.JsonRpcTestN
         }
 
         [Test()]
+        public void TestExtraPositionalParameters()
+        {
+            string request = @"{method:'ReturnsDateTime',params:[1,2,'mytext'],id:1}";
+            var result = JsonRpcProcessor.Process(request);
+            result.Wait();
+            Assert.IsTrue(result.Result.Contains("error"));
+            Assert.IsTrue(result.Result.Contains("\"code\":-32602"));
+        }
+
+        [Test()]
         public void TestCustomParameterName()
         {
             Func<string, string> request = (string paramName) => String.Format("{{method:'TestCustomParameterName',params:{{ {0}:'some string'}},id:1}}", paramName);

--- a/Json-Rpc/Handler.cs
+++ b/Json-Rpc/Handler.cs
@@ -250,7 +250,7 @@
             if (Rpc.Params is Newtonsoft.Json.Linq.JArray)
             {
                 var jarr = ((Newtonsoft.Json.Linq.JArray)Rpc.Params);
-                for (int i = 0; i < loopCt; i++)
+                for (int i = 0; i < loopCt && i < metadata.parameters.Length; i++)
                 {
                     parameters[i] = CleanUpParameter(jarr[i], metadata.parameters[i]);
                 }


### PR DESCRIPTION
Hi,

When using the TestServer_Console program, I've noticed that if a request document (for instance: {'method':'add','params':[1,2,3],'id':2} ) has an excess of positional parameters, an unhandled exception of type IndexOutOfRangeException happens on Handler.cs:255

This PR has the fix, and an additional unit test.

Regards,
Pedro
