### PR TITLE
Allow jsonrpc property of JsonResponse to be settable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
 .nuget/NuGet.exe
+.vs/

--- a/AustinHarris.JsonRpcTestN/Test.cs
+++ b/AustinHarris.JsonRpcTestN/Test.cs
@@ -1889,6 +1889,17 @@ namespace AustinHarris.JsonRpcTestN
             Assert.AreEqual(expected, result.Result);
         }
 
+        [Test()]
+        public void TestWrongParamType()
+        {
+            string request = @"{method:'TestOptionalParamdouble',params:{input:'mytext'},id:1}";
+            var result = JsonRpcProcessor.Process(request);
+            result.Wait();
+            Assert.IsTrue(result.Result.Contains("error"));
+            Assert.IsTrue(result.Result.Contains("\"code\":-32603"));
+        }
+
+
         private static void AssertJsonAreEqual(string expectedJson, string actualJson)
         {
             Newtonsoft.Json.Linq.JObject expected = (Newtonsoft.Json.Linq.JObject)Newtonsoft.Json.JsonConvert.DeserializeObject(expectedJson);

--- a/AustinHarris.JsonRpcTestN/Test.cs
+++ b/AustinHarris.JsonRpcTestN/Test.cs
@@ -1844,6 +1844,16 @@ namespace AustinHarris.JsonRpcTestN
         }
 
         [Test()]
+        public void TestExtraPositionalParameters()
+        {
+            string request = @"{method:'ReturnsDateTime',params:[1,2,'mytext'],id:1}";
+            var result = JsonRpcProcessor.Process(request);
+            result.Wait();
+            Assert.IsTrue(result.Result.Contains("error"));
+            Assert.IsTrue(result.Result.Contains("\"code\":-32602"));
+        }
+
+        [Test()]
         public void TestCustomParameterName()
         {
             Func<string, string> request = (string paramName) => String.Format("{{method:'TestCustomParameterName',params:{{ {0}:'some string'}},id:1}}", paramName);

--- a/Json-Rpc/Handler.cs
+++ b/Json-Rpc/Handler.cs
@@ -250,7 +250,7 @@
             if (Rpc.Params is Newtonsoft.Json.Linq.JArray)
             {
                 var jarr = ((Newtonsoft.Json.Linq.JArray)Rpc.Params);
-                for (int i = 0; i < loopCt; i++)
+                for (int i = 0; i < loopCt && i < metadata.parameters.Length; i++)
                 {
                     parameters[i] = CleanUpParameter(jarr[i], metadata.parameters[i]);
                 }

--- a/Json-Rpc/Handler.cs
+++ b/Json-Rpc/Handler.cs
@@ -431,34 +431,34 @@
                     return bob.Value;
                 }
 
-                // Avoid calling DeserializeObject on types that JValue has an explicit converter for
-                // try to optimize for the most common types
-                if (metaData.ObjectType == typeof(string)) return (string)bob;
-                if (metaData.ObjectType == typeof(int)) return (int)bob;
-                if (metaData.ObjectType == typeof(double)) return (double)bob;
-                if (metaData.ObjectType == typeof(float)) return (float)bob;
-                //if (metaData.ObjectType == typeof(long)) return (long)bob;
-                //if (metaData.ObjectType == typeof(uint)) return (uint)bob;
-                //if (metaData.ObjectType == typeof(ulong)) return (ulong)bob;
-                //if (metaData.ObjectType == typeof(byte[])) return (byte[])bob;
-                //if (metaData.ObjectType == typeof(Guid)) return (Guid)bob;
-                if (metaData.ObjectType == typeof(decimal)) return (decimal)bob;
-                //if (metaData.ObjectType == typeof(TimeSpan)) return (TimeSpan)bob;
-                //if (metaData.ObjectType == typeof(short)) return (short)bob;
-                //if (metaData.ObjectType == typeof(ushort)) return (ushort)bob;
-                //if (metaData.ObjectType == typeof(char)) return (char)bob;
-                //if (metaData.ObjectType == typeof(DateTime)) return (DateTime)bob;
-                //if (metaData.ObjectType == typeof(bool)) return (bool)bob;
-                //if (metaData.ObjectType == typeof(DateTimeOffset)) return (DateTimeOffset)bob;
-
-                if (metaData.ObjectType.IsAssignableFrom(typeof(JValue)))
-                    return bob;
-
                 try
                 {
+                    // Avoid calling DeserializeObject on types that JValue has an explicit converter for
+                    // try to optimize for the most common types
+                    if (metaData.ObjectType == typeof(string)) return (string)bob;
+                    if (metaData.ObjectType == typeof(int)) return (int)bob;
+                    if (metaData.ObjectType == typeof(double)) return (double)bob;
+                    if (metaData.ObjectType == typeof(float)) return (float)bob;
+                    //if (metaData.ObjectType == typeof(long)) return (long)bob;
+                    //if (metaData.ObjectType == typeof(uint)) return (uint)bob;
+                    //if (metaData.ObjectType == typeof(ulong)) return (ulong)bob;
+                    //if (metaData.ObjectType == typeof(byte[])) return (byte[])bob;
+                    //if (metaData.ObjectType == typeof(Guid)) return (Guid)bob;
+                    if (metaData.ObjectType == typeof(decimal)) return (decimal)bob;
+                    //if (metaData.ObjectType == typeof(TimeSpan)) return (TimeSpan)bob;
+                    //if (metaData.ObjectType == typeof(short)) return (short)bob;
+                    //if (metaData.ObjectType == typeof(ushort)) return (ushort)bob;
+                    //if (metaData.ObjectType == typeof(char)) return (char)bob;
+                    //if (metaData.ObjectType == typeof(DateTime)) return (DateTime)bob;
+                    //if (metaData.ObjectType == typeof(bool)) return (bool)bob;
+                    //if (metaData.ObjectType == typeof(DateTimeOffset)) return (DateTimeOffset)bob;
+
+                    if (metaData.ObjectType.IsAssignableFrom(typeof(JValue)))
+                        return bob;
+
                     return bob.ToObject(metaData.ObjectType);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     // no need to throw here, they will
                     // get an invalid cast exception right after this.
@@ -472,7 +472,7 @@
                         return JsonConvert.DeserializeObject((string)p, metaData.ObjectType);
                     return JsonConvert.DeserializeObject(p.ToString(), metaData.ObjectType);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     // no need to throw here, they will
                     // get an invalid cast exception right after this.

--- a/Json-Rpc/JsonResponse.cs
+++ b/Json-Rpc/JsonResponse.cs
@@ -13,7 +13,7 @@ namespace AustinHarris.JsonRpc
     public class JsonResponse
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "jsonrpc")]
-        public string JsonRpc { get { return "2.0"; } }
+        public string JsonRpc { get; set; } = "2.0";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "result")]
         public object Result { get; set; }
@@ -32,7 +32,7 @@ namespace AustinHarris.JsonRpc
     public class JsonResponse<T>
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "jsonrpc")]
-        public string JsonRpc { get { return "2.0"; } }
+        public string JsonRpc { get; set; } = "2.0";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "result")]
         public T Result { get; set; }

--- a/Json-Rpc/JsonRpcProcessor.cs
+++ b/Json-Rpc/JsonRpcProcessor.cs
@@ -101,6 +101,7 @@ namespace AustinHarris.JsonRpc
 
                     if (data == null) continue;
 
+                    jsonResponse.JsonRpc = data.JsonRpc;
                     jsonResponse.Error = data.Error;
                     jsonResponse.Result = data.Result;
 
@@ -119,8 +120,10 @@ namespace AustinHarris.JsonRpc
                     StringWriter sw = new StringWriter();
                     JsonTextWriter writer = new JsonTextWriter(sw);
                     writer.WriteStartObject();
-                    writer.WritePropertyName("jsonrpc"); writer.WriteValue("2.0");
-
+                    if (!string.IsNullOrEmpty(jsonResponse.JsonRpc))
+                    {
+                        writer.WritePropertyName("jsonrpc"); writer.WriteValue(jsonResponse.JsonRpc);
+                    }
                     if (jsonResponse.Error != null)
                     {
                         writer.WritePropertyName("error"); writer.WriteRawValue(JsonConvert.SerializeObject(jsonResponse.Error));


### PR DESCRIPTION
Setting this property to null for instance in a PostProcess() function would omit the "2.0" version to be included on every response.