### PR TITLE
Fix for ticket #109 - validate request.id property 

### DIFF
--- a/AustinHarris.JsonRpcTestN/Test.cs
+++ b/AustinHarris.JsonRpcTestN/Test.cs
@@ -1899,6 +1899,15 @@ namespace AustinHarris.JsonRpcTestN
             Assert.IsTrue(result.Result.Contains("\"code\":-32603"));
         }
 
+        [Test()]
+        public void TestWrongIdType()
+        {
+            string request = @"{method:'TestOptionalParamdouble',params:{input:5},id:{what:4,that:3}}";
+            var result = JsonRpcProcessor.Process(request);
+            result.Wait();
+            Assert.IsTrue(result.Result.Contains("error"));
+            Assert.IsTrue(result.Result.Contains("\"code\":-32600"));
+        }
 
         private static void AssertJsonAreEqual(string expectedJson, string actualJson)
         {

--- a/Json-Rpc/JsonRpcProcessor.cs
+++ b/Json-Rpc/JsonRpcProcessor.cs
@@ -93,6 +93,11 @@ namespace AustinHarris.JsonRpc
                     jsonResponse.Error = handler.ProcessParseException(jsonRpc,
                         new JsonRpcException(-32600, "Invalid Request", "Missing property 'method'"));
                 }
+                else if (!isSimpleValueType(jsonRequest.Id))
+                {
+                    jsonResponse.Error = handler.ProcessParseException(jsonRpc,
+                        new JsonRpcException(-32600, "Invalid Request", "Id property must be either null or string or integer."));
+                }
                 else
                 {
                     jsonResponse.Id = jsonRequest.Id;
@@ -173,6 +178,16 @@ namespace AustinHarris.JsonRpc
                 else if (json[i] == '[') return false;
             }
             return true;
+        }
+
+        private static bool isSimpleValueType(object property)
+        {
+            if (property == null)
+                return true;
+            return property.GetType() == typeof(System.String) ||
+                property.GetType() == typeof(System.Int64) ||
+                property.GetType() == typeof(System.Int32) ||
+                property.GetType() == typeof(System.Int16);
         }
     }
 }


### PR DESCRIPTION
Validate request.id property to conform the json-rpc 2.0 standard that allows only null, strings and integral numbers for this property; this PR adds a new test case, and the validation avoids the exception when a request object has an invalid id.